### PR TITLE
Hotfix: fixed default values for `namespace` and `tf_prefix` args

### DIFF
--- a/aegis_bringup/launch/bringup.launch.py
+++ b/aegis_bringup/launch/bringup.launch.py
@@ -19,9 +19,9 @@ from launch_ros.substitutions import FindPackageShare
 
 def launch_setup(context: LaunchContext) -> list[IncludeLaunchDescription]:
 
-    namespace = LaunchConfiguration("namespace")
+    namespace = LaunchConfiguration("namespace", default="")
     launch_args = {
-        "tf_prefix": LaunchConfiguration("tf_prefix"),
+        "tf_prefix": LaunchConfiguration("tf_prefix", default=""),
         "mock_hardware": LaunchConfiguration("mock_hardware"),
         "launch_rviz": LaunchConfiguration("launch_rviz"),
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Till the issue #13 will be resolved, the default values of the `namespace` and `tf_prefix` args must be provided in different way.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ :cactus:  ] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [ :cactus: ] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [hash](link)
