### PR TITLE
Hotfix: Update `ros2_net_fr_driver` commit hash

### DIFF
--- a/aegis/CHANGELOG.md
+++ b/aegis/CHANGELOG.md
@@ -19,4 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [PR-18](https://github.com/AGH-CEAI/aegis_ros/pull/18) - Updated the `ros2_net_ft_driver` to fix missing `curlpp-dev` depenendecy.
+
 ### Security

--- a/aegis/CHANGELOG.md
+++ b/aegis/CHANGELOG.md
@@ -19,6 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* [PR-18](https://github.com/AGH-CEAI/aegis_ros/pull/18) - Updated the `ros2_net_ft_driver` to fix missing `curlpp-dev` depenendecy.
+* [PR-18](https://github.com/AGH-CEAI/aegis_ros/pull/18) - Updated the `ros2_net_ft_driver` to fix missing `curlpp-dev` dependency.
 
 ### Security

--- a/aegis/aegis.repos
+++ b/aegis/aegis.repos
@@ -2,7 +2,7 @@ repositories:
   ros2_net_ft_driver:
     type: git
     url: https://github.com/AGH-CEAI/ros2_net_ft_driver
-    version: 9633eef704d0c3940f4abce9269d842eaf0c9138
+    version: ea11d1f3f58cee2eabf233258d33f144d88f6907
   robotiq_hande_description:
     type: git
     url: https://github.com/AGH-CEAI/robotiq_hande_description


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fixes the missing dependency, which was originally addressed in AGH-CEAI/ros2_net_ft_driver/pull/4

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Related PRs:
* https://github.com/AGH-CEAI/ros2_net_ft_driver/pull/4

<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: None
