### PR TITLE
Enable virtual tool communication port

### DIFF
--- a/aegis_control/CHANGELOG.md
+++ b/aegis_control/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [PR-16](https://github.com/AGH-CEAI/aegis_ros/pull/16) - Smoother controller_manager node config composition.
 * [PR-17](https://github.com/AGH-CEAI/aegis_ros/pull/17) - Added launch file for the ros2_net_ft_driver.
+* [PR-20] (https://github.com/AGH-CEAI/aegis_ros/pull/20) - Automatic initialization of the virtual serial port.
 
 ### Deprecated
 

--- a/aegis_control/launch/ur_driver.launch.py
+++ b/aegis_control/launch/ur_driver.launch.py
@@ -19,7 +19,7 @@ class URConfig:
         self.ur_type = "ur5e"
         self.robot_ip = "aegis_ur"
 
-        self.use_tool_communication = "false"
+        self.use_tool_communication = "true"
         self.tool_device_name = "/tmp/ttyUR"
 
         self.real_initial_joint_controller = "scaled_joint_trajectory_controller"

--- a/aegis_description/CHANGELOG.md
+++ b/aegis_description/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [PR-9](https://github.com/AGH-CEAI/aegis_ros/pull/9) - Launch and URDF files completely revamped.
 * [PR-17](https://github.com/AGH-CEAI/aegis_ros/pull/17) - Set default F/T sensor ip address.
+* [PR-20] (https://github.com/AGH-CEAI/aegis_ros/pull/20) - Automatic initialization of the virtual serial port.
 
 ### Deprecated
 

--- a/aegis_description/urdf/modules/ur_definition.xacro
+++ b/aegis_description/urdf/modules/ur_definition.xacro
@@ -25,7 +25,7 @@
     <xacro:arg name="reverse_ip" default="0.0.0.0"/>
 
     <!--   tool communication related parameters-->
-    <xacro:arg name="use_tool_communication" default="false"/>
+    <xacro:arg name="use_tool_communication" default="true"/>
     <xacro:arg name="tool_voltage" default="0"/>
     <xacro:arg name="tool_device_name" default="/tmp/ttyUR"/>
 


### PR DESCRIPTION
## Description
This PR enables the virtual serial port for communication with the tool via RS485.


## Motivation and context
This change is necessary to integrate the gripper by configuring the virtual serial port for communication. 


## How has this been tested?
Manually, on the Geonosis PC.


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.