### PR TITLE
Add point cloud

### DIFF
--- a/aegis_bringup/docs/launch_diagram.plantuml
+++ b/aegis_bringup/docs/launch_diagram.plantuml
@@ -27,9 +27,10 @@ package aegis_control {
         Node ros2_control::controllers_spawner()
     }
     class depthai_cameras_driver << (L,#FF7700) LaunchFile >> {
-        Node depthai_ros_driver::create_camera_node()
-        Node image_proc::create_rectify_node()
-        Node depthai_filters::create_spatial_bb_node()
+        Node depthai_ros_driver::oak_d_pro_scene()
+        Node image_proc::oak_d_pro_scene_rectify_color_node()
+        Node depthai_filters::oak_d_pro_scene_spatial_bb_node()
+        Node depth_image_proc::oak_d_pro_scene_point_cloud_xyzrgb_node()
     }
 
     package config {

--- a/aegis_control/CHANGELOG.md
+++ b/aegis_control/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [PR-9](https://github.com/AGH-CEAI/aegis_ros/pull/9) - Initial version of the `aegis_control` package.
 * [PR-21](https://github.com/AGH-CEAI/aegis_ros/pull/21) - Initial version of the DepthAI driver with support for the OAK-D Pro camera.
+* [PR-24](https://github.com/AGH-CEAI/aegis_ros/pull/24) - Added a point cloud node.
 
 ### Changed
 

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -74,6 +74,7 @@ def launch_setup(context):
         create_camera_node(name_pro_scene, tf_params_pro_scene, params_file, log_level),
         create_rectify_node(name_pro_scene),
         create_spatial_bb_node(name_pro_scene, params_file),
+        create_point_cloud_node(name_pro_scene),
     ]
 
 
@@ -136,6 +137,25 @@ def create_spatial_bb_node(name, params_file):
                     ("spatial_bb", name + "/spatial_bb"),
                 ],
                 parameters=[params_file],
+            ),
+        ],
+    )
+
+
+def create_point_cloud_node(name):
+    return LoadComposableNodes(
+        target_container=name + "_container",
+        composable_node_descriptions=[
+            ComposableNode(
+                package="depth_image_proc",
+                plugin="depth_image_proc::PointCloudXyzrgbNode",
+                name=name + "_point_cloud_xyzrgb_node",
+                remappings=[
+                    ("rgb/camera_info", name + "/rgb/camera_info"),
+                    ("rgb/image_rect_color", name + "/rgb/image_rect"),
+                    ("depth_registered/image_rect", name + "/stereo/image_raw"),
+                    ("/points", name + "/pointcloud"),
+                ],
             ),
         ],
     )

--- a/aegis_moveit_config/config/moveit.rviz
+++ b/aegis_moveit_config/config/moveit.rviz
@@ -1,11 +1,11 @@
 Panels:
   - Class: rviz_common/Displays
-    Help Height: 146
+    Help Height: 0
     Name: Displays
     Property Tree Widget:
       Expanded: ~
       Splitter Ratio: 0.5
-    Tree Height: 189
+    Tree Height: 325
   - Class: rviz_common/Help
     Name: Help
   - Class: rviz_common/Views
@@ -453,6 +453,40 @@ Visualization Manager:
       Torque Arrow Scale: 1
       Torque Color: 204; 204; 51
       Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: /oak_d_pro_scene/pointcloud
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
     - Class: rviz_default_plugins/Camera
       Enabled: true
       Far Plane Distance: 100
@@ -469,6 +503,7 @@ Visualization Manager:
       Visibility:
         Grid: true
         MotionPlanning: true
+        PointCloud2: true
         TF: true
         Value: true
         Wrench: true
@@ -516,7 +551,7 @@ Window Geometry:
     collapsed: false
   Displays:
     collapsed: false
-  Height: 1403
+  Height: 1371
   Help:
     collapsed: false
   Hide Left Dock: false
@@ -525,9 +560,9 @@ Window Geometry:
     collapsed: false
   MotionPlanning - Trajectory Slider:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000100000000000002b400000521fc0200000008fb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000004100fffffffb000000100044006900730070006c006100790073010000003d0000018c000000c900fffffffb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e006701000001cf0000017d0000017d00fffffffb0000000800480065006c0070000000029a0000006e0000006e00fffffffb0000000a0056006900650077007300000004510000010d000000a400fffffffb0000000c00430061006d00650072006100000003a6000001b80000000000000000fb0000000c00430061006d006500720061010000032c000002140000000000000000fb0000000c00430061006d00650072006101000003520000020c0000002800ffffff000007460000052100000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000100000000000002b400000505fc0200000008fb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000003f00fffffffb000000100044006900730070006c006100790073010000003b00000180000000c700fffffffb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e006701000001c1000002330000016900fffffffb0000000800480065006c0070000000029a0000006e0000006e00fffffffb0000000a0056006900650077007300000004510000010d000000a000fffffffb0000000c00430061006d00650072006101000003fa000001460000002800fffffffb0000000c00430061006d006500720061010000032c000002140000000000000000fb0000000c00430061006d00650072006101000003520000020c0000000000000000000007040000050500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Views:
     collapsed: false
-  Width: 2560
-  X: 0
-  Y: 0
+  Width: 2494
+  X: 66
+  Y: 32

--- a/aegis_moveit_config/launch/move_group.launch.py
+++ b/aegis_moveit_config/launch/move_group.launch.py
@@ -287,27 +287,3 @@ def prepare_scene_objects_manager_node(paths: AegisPathsCfg) -> Node:
 #         ],
 #         output="screen",
 #     )
-
-# TODO(issue#6) enable RGBD it for real hardware
-# def rgbd_point_cloud_node() -> Node:
-#     return ComposableNodeContainer(
-#         name="container0",
-#         namespace="",
-#         package="rclcpp_components",
-#         executable="component_container",
-#         composable_node_descriptions=[
-#             ComposableNode(
-#                 package="depth_image_proc",
-#                 plugin="depth_image_proc::PointCloudXyzrgbNode",
-#                 name="point_cloud_xyzrgb_node",
-#                 remappings=[
-#                     ("rgb/camera_info", "/color_camera_info"),
-#                     ("rgb/image_rect_color", "/camera_image_color"),
-#                     ("depth_registered/image_rect", "/camera_image_depth"),
-#                     ("/points", "/pointcloud"),
-#                 ],
-#             ),
-#         ],
-#         output="screen",
-#         parameters=[{"use_sim_time": True}],
-#     )


### PR DESCRIPTION
## Description
This PR introduces a new ROS node for generating a point cloud from depth and RGB images.

Closes #6 

## Motivation and context
This change enables 3D perception for the robot by generating a point cloud from the scene camera. 


## Screenshots
![pointcloud](https://github.com/user-attachments/assets/d62f8856-9c59-4281-a28f-982fc094a8d6)


## How has this been tested?
Manually, on the Geonosis PC.


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.