### PR TITLE
Disable DepthAI nodes with `mock_hardware` flag

### DIFF
--- a/aegis_control/CHANGELOG.md
+++ b/aegis_control/CHANGELOG.md
@@ -9,14 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [PR-9](https://github.com/AGH-CEAI/aegis_ros/pull/9) - Initial version of the `aegis_control` package.
 * [PR-21](https://github.com/AGH-CEAI/aegis_ros/pull/21) - Initial version of the DepthAI driver with support for the OAK-D Pro camera.
+* [PR-9](https://github.com/AGH-CEAI/aegis_ros/pull/9) - Initial version of the `aegis_control` package.
 
 ### Changed
 
-* [PR-16](https://github.com/AGH-CEAI/aegis_ros/pull/16) - Smoother controller_manager node config composition.
-* [PR-17](https://github.com/AGH-CEAI/aegis_ros/pull/17) - Added launch file for the ros2_net_ft_driver.
+* [PR-27](https://github.com/AGH-CEAI/aegis_ros/pull/27) - DepthAI nodes can be disabled with `mock_hardware` flag.
 * [PR-20] (https://github.com/AGH-CEAI/aegis_ros/pull/20) - Automatic initialization of the virtual serial port.
+* [PR-17](https://github.com/AGH-CEAI/aegis_ros/pull/17) - Added launch file for the ros2_net_ft_driver.
+* [PR-16](https://github.com/AGH-CEAI/aegis_ros/pull/16) - Smoother controller_manager node config composition.
 
 ### Deprecated
 

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -9,10 +9,10 @@ from launch_ros.substitutions import FindPackageShare
 
 class DepthAIConfig:
     def __init__(self):
-        self.params_file = (
-            LaunchConfiguration("params_file", default="oak_d_pro_scene"),
+        self.name_pro_scene = LaunchConfiguration(
+            "name_pro_scene", default="oak_d_pro_scene"
         )
-        self.name_pro_scene = PathJoinSubstitution(
+        self.params_file = PathJoinSubstitution(
             [
                 FindPackageShare("aegis_control"),
                 "config",
@@ -50,7 +50,7 @@ class DepthAIConfig:
         self.cam_yaw_pro_scene = LaunchConfiguration("cam_yaw_pro_scene", default="0")
 
 
-def generate_launch_description():
+def generate_launch_description() -> LaunchDescription:
     return LaunchDescription([OpaqueFunction(function=launch_setup)])
 
 
@@ -67,7 +67,7 @@ def launch_setup(context) -> list[Node]:
     tf_params_pro_scene = {
         "camera": {
             "i_publish_tf_from_calibration": False,
-            "i_tf_tf_prefix": cfg.name_pro_scene,
+            "i_tf_tf_prefix": name_pro_scene_str,
             "i_tf_camera_model": cfg.cam_model_pro_scene,
             "i_tf_parent_frame": cfg.parent_frame_pro_scene.perform(context),
             "i_tf_base_frame": cfg.base_frame_pro_scene.perform(context),
@@ -95,7 +95,7 @@ def launch_setup(context) -> list[Node]:
 
 def create_camera_node(
     mock_hardware: LaunchConfiguration,
-    name: LaunchConfiguration,
+    name: str,
     tf_params: dict,
     params_file: LaunchConfiguration,
     log_level: str,
@@ -120,7 +120,7 @@ def create_camera_node(
 
 
 def create_rectify_node(
-    mock_hardware: LaunchConfiguration, name: LaunchConfiguration
+    mock_hardware: LaunchConfiguration, name: str
 ) -> LoadComposableNodes:
     return LoadComposableNodes(
         condition=UnlessCondition(mock_hardware),
@@ -148,7 +148,7 @@ def create_rectify_node(
 
 def create_spatial_bb_node(
     mock_hardware: LaunchConfiguration,
-    name: LaunchConfiguration,
+    name: str,
     params_file: LaunchConfiguration,
 ) -> LoadComposableNodes:
     return LoadComposableNodes(

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -173,7 +173,9 @@ def create_spatial_bb_node(
     )
 
 
-def create_point_cloud_node(mock_hardware: LaunchConfiguration, name: str) -> LoadComposableNodes:
+def create_point_cloud_node(
+    mock_hardware: LaunchConfiguration, name: str
+) -> LoadComposableNodes:
     return LoadComposableNodes(
         condition=UnlessCondition(mock_hardware),
         target_container=name + "_container",

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -1,7 +1,7 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes
+from launch_ros.actions import Node, ComposableNodeContainer, LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 
@@ -77,7 +77,13 @@ def launch_setup(context):
     ]
 
 
-def create_camera_node(name, tf_params, params_file, log_level):
+def create_camera_node(
+    mock_hardware: LaunchConfiguration,
+    name: LaunchConfiguration,
+    tf_params: dict,
+    params_file: LaunchConfiguration,
+    log_level: str,
+) -> LoadComposableNodes:
     return ComposableNodeContainer(
         name=name + "_container",
         namespace="",
@@ -96,7 +102,9 @@ def create_camera_node(name, tf_params, params_file, log_level):
     )
 
 
-def create_rectify_node(name):
+def create_rectify_node(
+    mock_hardware: LaunchConfiguration, name: LaunchConfiguration
+) -> LoadComposableNodes:
     return LoadComposableNodes(
         target_container=name + "_container",
         composable_node_descriptions=[
@@ -120,7 +128,11 @@ def create_rectify_node(name):
     )
 
 
-def create_spatial_bb_node(name, params_file):
+def create_spatial_bb_node(
+    mock_hardware: LaunchConfiguration,
+    name: LaunchConfiguration,
+    params_file: LaunchConfiguration,
+) -> LoadComposableNodes:
     return LoadComposableNodes(
         target_container=name + "_container",
         composable_node_descriptions=[

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -90,7 +90,7 @@ def launch_setup(context) -> list[Node]:
         ),
         create_rectify_node(cfg.mock_hardware, name_pro_scene_str),
         create_spatial_bb_node(cfg.mock_hardware, name_pro_scene_str, cfg.params_file),
-        create_point_cloud_node(cfg.mock_hardware, name_pro_scene),
+        create_point_cloud_node(cfg.mock_hardware, name_pro_scene_str),
     ]
 
 

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -1,5 +1,6 @@
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.actions import OpaqueFunction
+from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node, ComposableNodeContainer, LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
@@ -100,6 +101,7 @@ def create_camera_node(
     log_level: str,
 ) -> LoadComposableNodes:
     return ComposableNodeContainer(
+        condition=UnlessCondition(mock_hardware),
         name=name + "_container",
         namespace="",
         package="rclcpp_components",
@@ -121,6 +123,7 @@ def create_rectify_node(
     mock_hardware: LaunchConfiguration, name: LaunchConfiguration
 ) -> LoadComposableNodes:
     return LoadComposableNodes(
+        condition=UnlessCondition(mock_hardware),
         target_container=name + "_container",
         composable_node_descriptions=[
             ComposableNode(
@@ -149,6 +152,7 @@ def create_spatial_bb_node(
     params_file: LaunchConfiguration,
 ) -> LoadComposableNodes:
     return LoadComposableNodes(
+        condition=UnlessCondition(mock_hardware),
         target_container=name + "_container",
         composable_node_descriptions=[
             ComposableNode(

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -6,74 +6,89 @@ from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 
 
+class DepthAIConfig:
+    def __init__(self):
+        self.params_file = (
+            LaunchConfiguration("params_file", default="oak_d_pro_scene"),
+        )
+        self.name_pro_scene = PathJoinSubstitution(
+            [
+                FindPackageShare("aegis_control"),
+                "config",
+                "cameras",
+                "depthai_cameras.yaml",
+            ]
+        )
+        # TODO(issue#26) create proper mock for the luxonis cameras
+        self.mock_hardware = LaunchConfiguration("mock_hardware", default="true")
+
+        self.cam_model_pro_scene = LaunchConfiguration(
+            "camera_model_pro_scene", default="OAK-D-S2"
+        )
+        self.parent_frame_pro_scene = LaunchConfiguration(
+            "parent_frame_pro_scene", default="cell"
+        )
+        self.base_frame_pro_scene = LaunchConfiguration(
+            "base_frame_pro_scene", default="oak_d_pro_scene_frame"
+        )
+        self.cam_pos_x_pro_scene = LaunchConfiguration(
+            "cam_pos_x_pro_scene", default="0.014"
+        )
+        self.cam_pos_y_pro_scene = LaunchConfiguration(
+            "cam_pos_y_pro_scene", default="0.33"
+        )
+        self.cam_pos_z_pro_scene = LaunchConfiguration(
+            "cam_pos_z_pro_scene", default="1.972"
+        )
+        self.cam_roll_pro_scene = LaunchConfiguration(
+            "cam_roll_pro_scene", default="1.5708"
+        )
+        self.cam_pitch_pro_scene = LaunchConfiguration(
+            "cam_pitch_pro_scene", default="1.5708"
+        )
+        self.cam_yaw_pro_scene = LaunchConfiguration("cam_yaw_pro_scene", default="0")
+
+
 def generate_launch_description():
-    declared_arguments = [
-        DeclareLaunchArgument("name_pro_scene", default_value="oak_d_pro_scene"),
-        DeclareLaunchArgument(
-            "params_file",
-            default_value=PathJoinSubstitution(
-                [
-                    FindPackageShare("aegis_control"),
-                    "config",
-                    "cameras",
-                    "depthai_cameras.yaml",
-                ]
-            ),
-        ),
-    ]
-
-    return LaunchDescription(
-        declared_arguments + [OpaqueFunction(function=launch_setup)]
-    )
+    return LaunchDescription([OpaqueFunction(function=launch_setup)])
 
 
-def launch_setup(context):
+def launch_setup(context) -> list[Node]:
     # TODO(issue#22): Setup global log level configuration
     log_level = "info"
     if context.environment.get("DEPTHAI_DEBUG") == "1":
         log_level = "debug"
 
-    params_file = LaunchConfiguration("params_file")
+    cfg = DepthAIConfig()
+    name_pro_scene_str = cfg.name_pro_scene.perform(context)
 
     # TODO(issue#23): Investigate the necessity of tf parameters
-
-    name_pro_scene = LaunchConfiguration("name_pro_scene").perform(context)
-    cam_model_pro_scene = LaunchConfiguration(
-        "camera_model_pro_scene", default="OAK-D-S2"
-    )
-    parent_frame_pro_scene = LaunchConfiguration(
-        "parent_frame_pro_scene", default="cell"
-    )
-    base_frame_pro_scene = LaunchConfiguration(
-        "base_frame_pro_scene", default="oak_d_pro_scene_frame"
-    )
-    cam_pos_x_pro_scene = LaunchConfiguration("cam_pos_x_pro_scene", default="0.014")
-    cam_pos_y_pro_scene = LaunchConfiguration("cam_pos_y_pro_scene", default="0.33")
-    cam_pos_z_pro_scene = LaunchConfiguration("cam_pos_z_pro_scene", default="1.972")
-    cam_roll_pro_scene = LaunchConfiguration("cam_roll_pro_scene", default="1.5708")
-    cam_pitch_pro_scene = LaunchConfiguration("cam_pitch_pro_scene", default="1.5708")
-    cam_yaw_pro_scene = LaunchConfiguration("cam_yaw_pro_scene", default="0")
-
     tf_params_pro_scene = {
         "camera": {
             "i_publish_tf_from_calibration": False,
-            "i_tf_tf_prefix": name_pro_scene,
-            "i_tf_camera_model": cam_model_pro_scene,
-            "i_tf_parent_frame": parent_frame_pro_scene.perform(context),
-            "i_tf_base_frame": base_frame_pro_scene.perform(context),
-            "i_tf_cam_pos_x": cam_pos_x_pro_scene.perform(context),
-            "i_tf_cam_pos_y": cam_pos_y_pro_scene.perform(context),
-            "i_tf_cam_pos_z": cam_pos_z_pro_scene.perform(context),
-            "i_tf_cam_roll": cam_roll_pro_scene.perform(context),
-            "i_tf_cam_pitch": cam_pitch_pro_scene.perform(context),
-            "i_tf_cam_yaw": cam_yaw_pro_scene.perform(context),
+            "i_tf_tf_prefix": cfg.name_pro_scene,
+            "i_tf_camera_model": cfg.cam_model_pro_scene,
+            "i_tf_parent_frame": cfg.parent_frame_pro_scene.perform(context),
+            "i_tf_base_frame": cfg.base_frame_pro_scene.perform(context),
+            "i_tf_cam_pos_x": cfg.cam_pos_x_pro_scene.perform(context),
+            "i_tf_cam_pos_y": cfg.cam_pos_y_pro_scene.perform(context),
+            "i_tf_cam_pos_z": cfg.cam_pos_z_pro_scene.perform(context),
+            "i_tf_cam_roll": cfg.cam_roll_pro_scene.perform(context),
+            "i_tf_cam_pitch": cfg.cam_pitch_pro_scene.perform(context),
+            "i_tf_cam_yaw": cfg.cam_yaw_pro_scene.perform(context),
         }
     }
 
     return [
-        create_camera_node(name_pro_scene, tf_params_pro_scene, params_file, log_level),
-        create_rectify_node(name_pro_scene),
-        create_spatial_bb_node(name_pro_scene, params_file),
+        create_camera_node(
+            cfg.mock_hardware,
+            name_pro_scene_str,
+            tf_params_pro_scene,
+            cfg.params_file,
+            log_level,
+        ),
+        create_rectify_node(cfg.mock_hardware, name_pro_scene_str),
+        create_spatial_bb_node(cfg.mock_hardware, name_pro_scene_str, cfg.params_file),
     ]
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
From now the `depthai_cameras_driver.launch.py` launch file (in the `aegis_control` package) dosen't run DepthAI nodes when the `mock_hardware` is enabled.

In addition, this file has been enhanced with:
* typings,
* LaunchConfiguration extraction to one place,

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* The logs spam in the console (about re-connecting to the camera) wasn't helping.

## Related PRs
* #25 
<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually, by running the whole project on genosis
    * with `mock_hardware:=true` 
    * with `mock_hardware:=false`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [8697umbbq](https://app.clickup.com/t/8697umbbq)
