### PR TITLE
Pre-commit config update - ruff & cmake formaters

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,6 @@
+with section("format"):  # noqa F821
+    line_width = 100
+    tab_size = 2
+    command_case = "lower"
+    max_subgroups_hwrap = 2
+    max_pargs_hwrap = 4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,9 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-added-large-files
+      - id: check-ast
       - id: check-case-conflict
+      - id: check-executables-have-shebangs
       - id: check-json
       - id: check-merge-conflict
       - id: check-symlinks
@@ -13,6 +15,7 @@ repos:
       - id: destroyed-symlinks
       - id: detect-private-key
       - id: end-of-file-fixer
+      - id: fix-byte-order-marker
       - id: mixed-line-ending
       - id: pretty-format-json
       - id: trailing-whitespace
@@ -20,15 +23,25 @@ repos:
         exclude: joint_limits.yaml # uses custom macro for deg<->rad transformation
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.4.1
     hooks:
       - id: codespell
         args: [-w]
 
-  - repo: https://github.com/psf/black
-    rev: 24.3.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.5
     hooks:
-      - id: black
+      - id: ruff
+        args:
+          - --fix
+          - --exit-non-zero-on-fix
+      - id: ruff-format
+
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+      - id: cmake-format
+      - id: cmake-lint
 
   - repo: https://github.com/tier4/pre-commit-hooks-ros
     rev: v0.10.0

--- a/aegis_bringup/launch/bringup.launch.py
+++ b/aegis_bringup/launch/bringup.launch.py
@@ -18,7 +18,6 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def launch_setup(context: LaunchContext) -> list[IncludeLaunchDescription]:
-
     namespace = LaunchConfiguration("namespace", default="")
     launch_args = {
         "tf_prefix": LaunchConfiguration("tf_prefix", default=""),
@@ -78,7 +77,6 @@ def set_namespace(namespace: LaunchConfiguration, description: list) -> list:
 
 
 def generate_launch_description() -> LaunchDescription:
-
     declared_arguments = []
 
     # TODO(issue#13) Debug the namespace and tf_prefix launch args

--- a/aegis_control/CMakeLists.txt
+++ b/aegis_control/CMakeLists.txt
@@ -4,9 +4,6 @@ project(aegis_control)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
-install(
-  DIRECTORY config launch
-  DESTINATION share/${PROJECT_NAME}
-)
+install(DIRECTORY config launch DESTINATION share/${PROJECT_NAME})
 
 ament_package()

--- a/aegis_control/launch/ft_sensor_driver.launch.py
+++ b/aegis_control/launch/ft_sensor_driver.launch.py
@@ -6,7 +6,7 @@ import sys
 
 run_path = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(run_path)
-from include.utils import controllers_spawner
+from include.utils import controllers_spawner  # noqa E402
 
 
 def generate_launch_description():

--- a/aegis_control/launch/start_drivers.launch.py
+++ b/aegis_control/launch/start_drivers.launch.py
@@ -12,7 +12,6 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description() -> LaunchDescription:
-
     launch_args = {
         "tf_prefix": LaunchConfiguration("tf_prefix", default=""),
         "mock_hardware": LaunchConfiguration("mock_hardware", default="false"),

--- a/aegis_control/launch/ur_driver.launch.py
+++ b/aegis_control/launch/ur_driver.launch.py
@@ -10,7 +10,7 @@ import sys
 
 run_path = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(run_path)
-from include.utils import str2bool, controllers_spawner
+from include.utils import str2bool, controllers_spawner  # noqa E402
 
 
 class URConfig:
@@ -31,9 +31,8 @@ def generate_launch_description() -> LaunchDescription:
 
 
 def launch_setup(context: LaunchContext) -> list[Node]:
-
     # tf_prefix is necessary to properly parse ur_controllers_cfg YAML file
-    tf_prefix = LaunchConfiguration("tf_prefix")
+    tf_prefix = LaunchConfiguration("tf_prefix")  # noqa F841
     mock_hardware = LaunchConfiguration("mock_hardware")
     mock_hardware_bool = str2bool(mock_hardware.perform(context))
 

--- a/aegis_description/CMakeLists.txt
+++ b/aegis_description/CMakeLists.txt
@@ -5,8 +5,11 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
 install(
-  DIRECTORY config meshes launch urdf rviz
-  DESTINATION share/${PROJECT_NAME}
-)
+  DIRECTORY config
+            meshes
+            launch
+            urdf
+            rviz
+  DESTINATION share/${PROJECT_NAME})
 
 ament_package()

--- a/aegis_description/launch/aegis_preview.launch.py
+++ b/aegis_description/launch/aegis_preview.launch.py
@@ -1,5 +1,4 @@
 from launch import LaunchDescription
-from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 from launch.actions import IncludeLaunchDescription
 from launch.substitutions import PathJoinSubstitution

--- a/aegis_description/launch/robot_description.launch.py
+++ b/aegis_description/launch/robot_description.launch.py
@@ -12,7 +12,6 @@ from launch_ros.descriptions import ParameterValue
 
 
 def generate_launch_description():
-
     tf_prefix = LaunchConfiguration("tf_prefix", default="")
     mock_hardware = LaunchConfiguration("mock_hardware", default="false")
 

--- a/aegis_moveit_config/CMakeLists.txt
+++ b/aegis_moveit_config/CMakeLists.txt
@@ -5,7 +5,9 @@ find_package(ament_cmake REQUIRED)
 
 ament_package()
 
-install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}
+install(
+  DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
   PATTERN "setup_assistant.launch" EXCLUDE)
 install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 install(FILES .setup_assistant DESTINATION share/${PROJECT_NAME})

--- a/aegis_moveit_config/launch/move_group.launch.py
+++ b/aegis_moveit_config/launch/move_group.launch.py
@@ -65,7 +65,6 @@ def generate_launch_description() -> LaunchDescription:
 
 
 def launch_setup(context: LaunchContext) -> list[Node]:
-
     mock_hardware = LaunchConfiguration("mock_hardware")
     launch_rviz = LaunchConfiguration("launch_rviz")
     # TODO(issue#5) enable real-time servo
@@ -114,7 +113,6 @@ def prepare_move_group_and_rviz_nodes(
     launch_rviz: LaunchConfiguration,
     paths: AegisPathsCfg,
 ) -> tuple[Node, Node]:
-
     robot_description_planning = {
         "robot_description_planning": paths.load_joint_limits_cfg()
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Pre-commit config update (change `black` to `ruff`, introduced cmake formatter).
* Formatting of the codebase.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To match configuration from AGH-CEAI/robotiq_hande_driver/pull/4 .

<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* No tests were made - it's just the code format.

## Related PRs
* AGH-CEAI/robotiq_hande_driver/pull/4

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- :cactus:  Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.
