### PR TITLE
Add OctoMap

### DIFF
--- a/aegis_moveit_config/CHANGELOG.md
+++ b/aegis_moveit_config/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [PR-31](https://github.com/AGH-CEAI/aegis_ros/pull/31) - Implemented octomap support.
+* [PR-31](https://github.com/AGH-CEAI/aegis_ros/pull/31) - Enabled [OctoMap](https://octomap.github.io/) support.
 * [PR-21](https://github.com/AGH-CEAI/aegis_ros/pull/21) - RViz camera visualization for the OAK-D Pro camera.
 * [PR-17](https://github.com/AGH-CEAI/aegis_ros/pull/17) - RViz wrench visualization for the F/T sensor.
 * [PR-8](https://github.com/AGH-CEAI/aegis_ros/pull/8) - Added semantic description of the robot cell and the scene camera.

--- a/aegis_moveit_config/CHANGELOG.md
+++ b/aegis_moveit_config/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [PR-7](https://github.com/AGH-CEAI/aegis_ros/pull/7) - Initial version of the Aegis ROS 2 packages.
-* [PR-8](https://github.com/AGH-CEAI/aegis_ros/pull/8) - Added semantic description of the robot cell and the scene camera.
-* [PR-17](https://github.com/AGH-CEAI/aegis_ros/pull/17) - RViz wrench visualization for the F/T sensor.
+* [PR-31](https://github.com/AGH-CEAI/aegis_ros/pull/31) - Implemented octomap support.
 * [PR-21](https://github.com/AGH-CEAI/aegis_ros/pull/21) - RViz camera visualization for the OAK-D Pro camera.
+* [PR-17](https://github.com/AGH-CEAI/aegis_ros/pull/17) - RViz wrench visualization for the F/T sensor.
+* [PR-8](https://github.com/AGH-CEAI/aegis_ros/pull/8) - Added semantic description of the robot cell and the scene camera.
+* [PR-7](https://github.com/AGH-CEAI/aegis_ros/pull/7) - Initial version of the Aegis ROS 2 packages.
 
 ### Changed
 

--- a/aegis_moveit_config/CHANGELOG.md
+++ b/aegis_moveit_config/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [PR-31](https://github.com/AGH-CEAI/aegis_ros/pull/31) - Enabled [OctoMap](https://octomap.github.io/) support.
+* [PR-33](https://github.com/AGH-CEAI/aegis_ros/pull/33) - Enabled [OctoMap](https://octomap.github.io/) support.
 * [PR-21](https://github.com/AGH-CEAI/aegis_ros/pull/21) - RViz camera visualization for the OAK-D Pro camera.
 * [PR-17](https://github.com/AGH-CEAI/aegis_ros/pull/17) - RViz wrench visualization for the F/T sensor.
 * [PR-8](https://github.com/AGH-CEAI/aegis_ros/pull/8) - Added semantic description of the robot cell and the scene camera.

--- a/aegis_moveit_config/config/moveit.rviz
+++ b/aegis_moveit_config/config/moveit.rviz
@@ -453,6 +453,29 @@ Visualization Manager:
       Torque Arrow Scale: 1
       Torque Color: 204; 204; 51
       Value: false
+    - Class: rviz_default_plugins/Camera
+      Enabled: true
+      Far Plane Distance: 100
+      Image Rendering: background and overlay
+      Name: Camera
+      Overlay Alpha: 0.5
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /oak_d_pro_scene/rgb/image_rect
+      Value: true
+      Visibility:
+        Grid: true
+        Image: true
+        MarkerArray: true
+        MotionPlanning: true
+        PointCloud2: true
+        TF: true
+        Value: true
+        Wrench: true
+      Zoom Factor: 1
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
@@ -487,27 +510,32 @@ Visualization Manager:
       Use Fixed Frame: true
       Use rainbow: true
       Value: false
-    - Class: rviz_default_plugins/Camera
-      Enabled: true
-      Far Plane Distance: 100
-      Image Rendering: background and overlay
-      Name: Camera
-      Overlay Alpha: 0.5
+    - Class: rviz_default_plugins/Image
+      Enabled: false
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
       Topic:
         Depth: 5
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /oak_d_pro_scene/rgb/image_rect
-      Value: true
-      Visibility:
-        Grid: true
-        MotionPlanning: true
-        PointCloud2: true
-        TF: true
-        Value: true
-        Wrench: true
-      Zoom Factor: 1
+        Value: /oak_d_pro_scene/overlay
+      Value: false
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: false
+      Name: MarkerArray
+      Namespaces:
+        {}
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /occupied_cells_vis_array
+      Value: false
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -526,25 +554,25 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 4.76232385635376
+      Distance: 4.190845012664795
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: -0.11557871848344803
-        Y: -0.2149348258972168
-        Z: 0.5267499089241028
+        X: -0.11182383447885513
+        Y: -0.09440480172634125
+        Z: 0.23323896527290344
       Focal Shape Fixed Size: false
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.27039822936058044
+      Pitch: 0.265398234128952
       Target Frame: ur_base
       Value: Orbit (rviz_default_plugins)
-      Yaw: 0.68178391456604
+      Yaw: 0.6917839050292969
     Saved: ~
 Window Geometry:
   Camera:
@@ -556,11 +584,13 @@ Window Geometry:
     collapsed: false
   Hide Left Dock: false
   Hide Right Dock: false
+  Image:
+    collapsed: false
   MotionPlanning:
     collapsed: false
   MotionPlanning - Trajectory Slider:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000100000000000002b400000505fc0200000008fb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000003f00fffffffb000000100044006900730070006c006100790073010000003b00000180000000c700fffffffb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e006701000001c1000002330000016900fffffffb0000000800480065006c0070000000029a0000006e0000006e00fffffffb0000000a0056006900650077007300000004510000010d000000a000fffffffb0000000c00430061006d00650072006101000003fa000001460000002800fffffffb0000000c00430061006d006500720061010000032c000002140000000000000000fb0000000c00430061006d00650072006101000003520000020c0000000000000000000007040000050500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000100000000000002b400000505fc0200000009fb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000003f00fffffffb000000100044006900730070006c006100790073010000003b00000180000000c700fffffffb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e006701000001c1000002330000016900fffffffb0000000800480065006c0070000000029a0000006e0000006e00fffffffb0000000a0056006900650077007300000004510000010d000000a000fffffffb0000000c00430061006d00650072006101000003fa000001460000002800fffffffb0000000c00430061006d006500720061010000032c000002140000000000000000fb0000000c00430061006d00650072006101000003520000020c0000000000000000fb0000000a0049006d0061006700650000000468000000d80000002800ffffff000007040000050500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Views:
     collapsed: false
   Width: 2494

--- a/aegis_moveit_config/config/octomap_updater.yaml
+++ b/aegis_moveit_config/config/octomap_updater.yaml
@@ -1,0 +1,9 @@
+sensors:
+  sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
+  point_cloud_topic: /oak_d_pro_scene/pointcloud
+  max_range: 2.0
+  point_subsample: 1
+  padding_offset: 0.1
+  padding_scale: 1.0
+  max_update_rate: 1.0
+  filtered_cloud_topic: filtered_cloud

--- a/aegis_moveit_config/launch/move_group.launch.py
+++ b/aegis_moveit_config/launch/move_group.launch.py
@@ -59,6 +59,9 @@ class AegisPathsCfg:
     def load_joint_limits_cfg(self) -> dict:
         return load_yaml(self.description_cfg_pkg_name, "config/ur5e/joint_limits.yaml")
 
+    def load_octomap_updater_cfg(self) -> dict:
+        return load_yaml(self.moveit_cfg_pkg_name, "config/octomap_updater.yaml")
+
 
 def generate_launch_description() -> LaunchDescription:
     return LaunchDescription([OpaqueFunction(function=launch_setup)])
@@ -70,49 +73,10 @@ def launch_setup(context: LaunchContext) -> list[Node]:
     # TODO(issue#5) enable real-time servo
     # launch_servo = LaunchConfiguration("launch_servo")
 
-    aegis_paths = AegisPathsCfg()
+    paths = AegisPathsCfg()
 
-    move_group_node, rviz_node = prepare_move_group_and_rviz_nodes(
-        mock_hardware=mock_hardware,
-        mock_hardware_bool=str2bool(context.perform_substitution(mock_hardware)),
-        launch_rviz=launch_rviz,
-        paths=aegis_paths,
-    )
+    mock_hardware_bool = str2bool(context.perform_substitution(mock_hardware))
 
-    tf_odom_node = prepare_static_tf_node("world", "odom")
-    scene_objects_manager_node = prepare_scene_objects_manager_node(aegis_paths)
-
-    nodes_to_start = [
-        move_group_node,
-        rviz_node,
-        tf_odom_node,
-        scene_objects_manager_node,
-        # TODO(issue#5) enable real-time servo
-        # servo_node(),
-        # TODO(issue#6) enable RGBD it for real hardware
-        # rgbd_point_cloud_node(),
-    ]
-
-    return nodes_to_start
-
-
-def get_robot_description_semantic(paths: AegisPathsCfg) -> dict:
-    robot_description_semantic_content = Command(
-        [paths.xacro_path, " ", paths.srdf_path]
-    )
-    return {
-        "robot_description_semantic": ParameterValue(
-            robot_description_semantic_content, value_type=str
-        )
-    }
-
-
-def prepare_move_group_and_rviz_nodes(
-    mock_hardware: LaunchConfiguration,
-    mock_hardware_bool: bool,
-    launch_rviz: LaunchConfiguration,
-    paths: AegisPathsCfg,
-) -> tuple[Node, Node]:
     robot_description_planning = {
         "robot_description_planning": paths.load_joint_limits_cfg()
     }
@@ -125,13 +89,11 @@ def prepare_move_group_and_rviz_nodes(
             "start_state_max_bounds_error": 0.1,
         }
     }
-
     ompl_planning_yaml = paths.load_ompl_planning_cfg()
     ompl_planning_pipeline_config["move_group"].update(ompl_planning_yaml)
 
     # Trajectory Execution Configuration
     controllers_yaml = paths.load_controllers_cfg()
-
     # TODO(issue#11) Extract configuration for real/fake controller to an external YAML
     if mock_hardware_bool:
         # the scaled_joint_trajectory_controller does not work on fake hardware
@@ -157,6 +119,14 @@ def prepare_move_group_and_rviz_nodes(
         "publish_transforms_updates": True,
     }
 
+    octomap_parameters = {
+        "frame_id": "world",
+        "resolution": 0.01,
+        "max_range": 2.0,
+    }
+
+    octomap_updater_parameters = paths.load_octomap_updater_cfg()
+
     # TODO(issue#1) integrate the warehouse with the Aegis setup
     # warehouse_ros_config = {
     #     "warehouse_plugin": "warehouse_ros_sqlite::DatabaseConnection",
@@ -176,11 +146,40 @@ def prepare_move_group_and_rviz_nodes(
         "robot_description_planning": robot_description_planning,
         "robot_description_semantic": get_robot_description_semantic(paths),
         "trajectory_execution": trajectory_execution,
+        "octomap_parameters": octomap_parameters,
+        "octomap_updater_parameters": octomap_updater_parameters,
         "mock_hardware": mock_hardware,
         "warehouse_ros_config": warehouse_ros_config,
     }
 
-    return prepare_move_group_node(node_cfg), prepare_rviz_node(node_cfg, paths)
+    move_group_node = prepare_move_group_node(node_cfg)
+    rviz_node = prepare_rviz_node(node_cfg, paths)
+    tf_odom_node = prepare_static_tf_node("world", "odom")
+    scene_objects_manager_node = prepare_scene_objects_manager_node(paths)
+    octomap_node = prepare_octomap_node(node_cfg)
+
+    nodes_to_start = [
+        move_group_node,
+        rviz_node,
+        tf_odom_node,
+        scene_objects_manager_node,
+        octomap_node,
+        # TODO(issue#5) enable real-time servo
+        # servo_node(),
+    ]
+
+    return nodes_to_start
+
+
+def get_robot_description_semantic(paths: AegisPathsCfg) -> dict:
+    robot_description_semantic_content = Command(
+        [paths.xacro_path, " ", paths.srdf_path]
+    )
+    return {
+        "robot_description_semantic": ParameterValue(
+            robot_description_semantic_content, value_type=str
+        )
+    }
 
 
 def prepare_move_group_node(cfg: dict) -> Node:
@@ -196,6 +195,8 @@ def prepare_move_group_node(cfg: dict) -> Node:
             cfg["trajectory_execution"],
             cfg["moveit_controllers"],
             cfg["planning_scene_monitor_parameters"],
+            cfg["octomap_parameters"],
+            cfg["octomap_updater_parameters"],
             {"use_sim_time": cfg["mock_hardware"]},
             {"publish_robot_description": True},
             {"publish_robot_description_semantic": True},
@@ -258,6 +259,16 @@ def prepare_scene_objects_manager_node(paths: AegisPathsCfg) -> Node:
         name="scene_objects_manager",
         output="screen",
         arguments=["--cfg", paths.scene_objects_cfg, "--frame", "ur_base"],
+    )
+
+
+def prepare_octomap_node(cfg: dict) -> Node:
+    return Node(
+        package="octomap_server",
+        executable="octomap_server_node",
+        output="screen",
+        parameters=[cfg["octomap_parameters"]],
+        remappings=[("/cloud_in", "/oak_d_pro_scene/pointcloud")],
     )
 
 

--- a/aegis_moveit_config/launch/move_group.launch.py
+++ b/aegis_moveit_config/launch/move_group.launch.py
@@ -158,7 +158,7 @@ def launch_setup(context: LaunchContext) -> list[Node]:
     scene_objects_manager_node = prepare_scene_objects_manager_node(paths)
     octomap_node = prepare_octomap_node(node_cfg)
 
-    nodes_to_start = [
+    return [
         move_group_node,
         rviz_node,
         tf_odom_node,
@@ -167,8 +167,6 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         # TODO(issue#5) enable real-time servo
         # servo_node(),
     ]
-
-    return nodes_to_start
 
 
 def get_robot_description_semantic(paths: AegisPathsCfg) -> dict:

--- a/aegis_moveit_config/package.xml
+++ b/aegis_moveit_config/package.xml
@@ -28,6 +28,7 @@
   <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>moveit_setup_assistant</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>octomap_server</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>rviz_common</exec_depend>


### PR DESCRIPTION
## Description
This PR introduces a new ROS node for generating an OctoMap from a point cloud.


## Motivation and context
This change allows the system to integrate 3D occupancy mapping by converting the scene camera's point cloud into an OctoMap. This will enable better environmental awareness for future collision checking and motion planning improvements.


## Screenshots
![screen1](https://github.com/user-attachments/assets/29047f55-eb54-423f-8587-2e32491d5afa)
![screen2](https://github.com/user-attachments/assets/f3758a8e-fc93-4465-b39a-843bc4809fa4)


## How has this been tested?
Manually, on the Geonosis PC.


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.