### PR TITLE
Add calibration of camera intrinsics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A complete suite of ROS 2 packages for the Aegis UR5e cobot station.
 * [aegis_description](./aegis_description/README.md): The description and configuration files of the Aegis robot station.
 * [aegis_director](./aegis_director/README.md): The "main" function for the robot workflow.
 * [aegis_moveit_config](./aegis_moveit_config/README.md): The configuration to run the [MoveIt 2](https://moveit.picknik.ai/main/index.html) framework.
+* [aegis_utils](./aegis_utils/README.md): Various utility functions and tools.
 
 ---
 

--- a/aegis_utils/CHANGELOG.md
+++ b/aegis_utils/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* [PR-50](https://github.com/AGH-CEAI/aegis_ros/pull/50) - Added calibration of camera intrinsics program.
 * [PR-47](https://github.com/AGH-CEAI/aegis_ros/pull/47) - Initial version of the `aegis_utils` package. Added calibration data collection program and corresponding positions configuration for Luxonis OAK-D SR tool camera.
 
 ### Changed

--- a/aegis_utils/README.md
+++ b/aegis_utils/README.md
@@ -42,3 +42,13 @@ ros2 run aegis_utils calib_data_collect -c tool_front_right -p ~/Documents/calib
 > ```yaml
 > i_laser_dot_brightness: 0
 > ```
+
+## Calibration of camera intrinsics
+This tool computes the intrinsic parameters of a camera using previously collected calibration images.
+It processes a set of chessboard pattern images and saves the resulting camera matrix and distortion coefficients.
+
+### Example usage
+It accepts the same arguments and uses the same default data path as the data collection tool described above. For example:
+```bash
+ros2 run aegis_utils calib_intrinsics -c tool_front_right
+```

--- a/aegis_utils/aegis_utils/calib_data_collect.py
+++ b/aegis_utils/aegis_utils/calib_data_collect.py
@@ -1,19 +1,19 @@
 import argparse
-import os
 import threading
 import time
+from pathlib import Path
 from typing import List, Dict, Optional
 
 import cv2
 import numpy as np
 import yaml
-from cv_bridge import CvBridge
 
 import rclpy
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node
 from ament_index_python.packages import get_package_share_directory
 from builtin_interfaces.msg import Time
+from cv_bridge import CvBridge
 from sensor_msgs.msg import Image
 
 from aegis_director.robot_director import RobotDirector
@@ -40,7 +40,7 @@ CAMERA_CONFIG = {
 }
 
 
-def load_positions(config_file_path: str) -> List[Dict[str, float]]:
+def load_positions(config_file_path: Path) -> List[Dict[str, float]]:
     with open(config_file_path, "r") as f:
         data = yaml.safe_load(f)
     return data.get("positions", data)
@@ -51,7 +51,7 @@ def get_timestamp(stamp: Time) -> float:
 
 
 class CalibCollectNode(Node):
-    def __init__(self, robot: RobotDirector, image_topic: str, data_path: str) -> None:
+    def __init__(self, robot: RobotDirector, image_topic: str, data_path: Path) -> None:
         super().__init__("calib_collect_node")
         self.robot = robot
         self.bridge = CvBridge()
@@ -96,14 +96,14 @@ class CalibCollectNode(Node):
             time.sleep(1)
         return None
 
-    def save_image(self, image: Optional[np.ndarray], path: str) -> None:
+    def save_image(self, image: Optional[np.ndarray], path: Path) -> None:
         if image is None:
             self.get_logger().warn("No image to save")
             return
         cv2.imwrite(path, image)
         self.get_logger().info(f"Saved image to: {path}")
 
-    def save_tcp(self, tcp_pose: Dict[str, List[float]], path: str) -> None:
+    def save_tcp(self, tcp_pose: Dict[str, List[float]], path: Path) -> None:
         with open(path, "w") as f:
             yaml.dump(
                 {
@@ -124,7 +124,7 @@ def collect_data(
     node: CalibCollectNode,
     robot: RobotDirector,
     positions: List[Dict[str, float]],
-    data_path: str,
+    data_path: Path,
     camera_name: str,
 ) -> None:
     node.move_to_home()
@@ -140,9 +140,9 @@ def collect_data(
         image = node.get_image(time_start)
         if image is not None:
             tcp_pose = robot.get_tcp_pose()
-            img_path = os.path.join(data_path, f"{camera_name}_view_{i}.png")
-            tcp_path = os.path.splitext(img_path)[0] + ".yaml"
-            node.save_image(image, img_path)
+            image_path = data_path / f"{camera_name}_image_{i}.png"
+            tcp_path = data_path / f"{camera_name}_tcp_{i}.yaml"
+            node.save_image(image, image_path)
             node.save_tcp(tcp_pose, tcp_path)
         else:
             node.log("No image received in time")
@@ -173,19 +173,17 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    package_share_path = os.path.join(get_package_share_directory("aegis_utils"))
-    camera_info = CAMERA_CONFIG[args.camera]
-    pos_config_path = os.path.join(
-        package_share_path, "config", camera_info["pos_config"]
-    )
-    image_topic = camera_info["topic"]
-
     if args.path:
-        data_path = os.path.join(os.path.expanduser(args.path), args.camera)
+        data_path = Path(args.path).expanduser() / args.camera
     else:
-        data_path = os.path.expanduser(f"~/ceai_ws/calibration_data/{args.camera}")
+        data_path = Path("~/ceai_ws/calibration_data").expanduser() / args.camera
 
-    os.makedirs(data_path, exist_ok=True)
+    data_path.mkdir(parents=True, exist_ok=True)
+
+    package_share_path = Path(get_package_share_directory("aegis_utils"))
+    camera_info = CAMERA_CONFIG[args.camera]
+    pos_config_path = package_share_path / "config" / camera_info["pos_config"]
+    image_topic = camera_info["topic"]
 
     rclpy.init()
     robot = RobotDirector(synchronous=True)

--- a/aegis_utils/aegis_utils/calib_intrinsics.py
+++ b/aegis_utils/aegis_utils/calib_intrinsics.py
@@ -1,7 +1,6 @@
 import argparse
-import glob
 import json
-import os
+from pathlib import Path
 
 import cv2
 from natsort import natsorted
@@ -15,7 +14,7 @@ CAMERA_CONFIG = {
 }
 
 
-def calibrate_intrinsics(data_path: str) -> None:
+def calibrate_intrinsics(data_path: Path) -> None:
     squares_x = 9
     squares_y = 6
     square_size = 0.03
@@ -27,9 +26,9 @@ def calibrate_intrinsics(data_path: str) -> None:
     )
     board.setLegacyPattern(True)
 
-    images = natsorted(glob.glob(os.path.join(os.path.expanduser(data_path), "*.png")))
+    image_paths = natsorted(data_path.glob("*_image_*.png"))
 
-    if len(images) == 0:
+    if not image_paths:
         print(f"No images found in {data_path}")
         return
 
@@ -37,8 +36,8 @@ def calibrate_intrinsics(data_path: str) -> None:
     all_ids = []
     image_size = None
 
-    for fname in images:
-        img = cv2.imread(fname)
+    for image_path in image_paths:
+        img = cv2.imread(str(image_path))
         img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
         image_size = img_gray.shape[::-1]
 
@@ -48,7 +47,7 @@ def calibrate_intrinsics(data_path: str) -> None:
                 corners, ids, img_gray, board
             )
             print(
-                f"{retval} ChArUco corners were detected in image {os.path.basename(fname)}"
+                f"{retval} ChArUco corners were detected in image {image_path.name}"
             )
             if charuco_ids is not None and len(charuco_ids) > 3:
                 all_corners.append(charuco_corners)
@@ -81,9 +80,7 @@ def calibrate_intrinsics(data_path: str) -> None:
         "squares_y": squares_y,
     }
 
-    intrinsics_path = os.path.join(
-        data_path, f"{os.path.basename(data_path)}_camera_intrinsics.json"
-    )
+    intrinsics_path = data_path / f"{data_path.name}_camera_intrinsics.json"
     with open(intrinsics_path, "w") as f:
         json.dump(calib_data, f, indent=4)
 
@@ -110,9 +107,9 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.path:
-        data_path = os.path.join(os.path.expanduser(args.path), args.camera)
+        data_path = Path(args.path).expanduser() / args.camera
     else:
-        data_path = os.path.expanduser(f"~/ceai_ws/calibration_data/{args.camera}")
+        data_path = Path("~/ceai_ws/calibration_data").expanduser() / args.camera
 
     calibrate_intrinsics(data_path)
 

--- a/aegis_utils/aegis_utils/calib_intrinsics.py
+++ b/aegis_utils/aegis_utils/calib_intrinsics.py
@@ -1,0 +1,112 @@
+import argparse
+import glob
+import json
+import os
+
+import cv2
+from natsort import natsorted
+
+CAMERA_CONFIG = {
+    "tool_front_right": {},
+    "tool_front_left": {},
+    "tool_right": {},
+    "tool_left": {},
+    "scene": {},
+}
+
+def calibrate_intrinsics(data_path):
+    squares_x = 9
+    squares_y = 6
+    square_size = 0.03
+    marker_size = 0.022
+
+    aruco_dict = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_6X6_1000)
+    board = cv2.aruco.CharucoBoard((squares_x, squares_y), square_size, marker_size, aruco_dict)
+    board.setLegacyPattern(True)
+
+    images = natsorted(glob.glob(os.path.join(os.path.expanduser(data_path), "*.png")))
+
+    if len(images) == 0:
+        print(f"No images found in {data_path}")
+        return
+
+    all_corners = []
+    all_ids = []
+    image_size = None
+
+    for fname in images:
+        img = cv2.imread(fname)
+        img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        image_size = img_gray.shape[::-1]
+
+        corners, ids, _ = cv2.aruco.detectMarkers(img_gray, aruco_dict)
+        if ids is not None and len(ids) > 0:
+            retval, charuco_corners, charuco_ids = cv2.aruco.interpolateCornersCharuco(corners, ids, img_gray, board)
+            print(f"{retval} ChArUco corners were detected in image {os.path.basename(fname)}")
+            if charuco_ids is not None and len(charuco_ids) > 3:
+                all_corners.append(charuco_corners)
+                all_ids.append(charuco_ids)
+
+    print(f"Found {len(all_corners)} valid images for calibration")
+
+    if len(all_corners) == 0:
+        print("No valid data for calibration")
+        return
+
+    ret, camera_matrix, dist_coeffs, rvecs, tvecs = cv2.aruco.calibrateCameraCharuco(
+        charucoCorners=all_corners,
+        charucoIds=all_ids,
+        board=board,
+        imageSize=image_size,
+        cameraMatrix=None,
+        distCoeffs=None
+    )
+
+    print("Camera matrix (K):\n", camera_matrix)
+    print("Distortion coefficients (D):\n", dist_coeffs)
+
+    calib_data = {
+        "camera_matrix": camera_matrix.tolist(),
+        "dist_coeffs": dist_coeffs.tolist(),
+        "square_size": square_size,
+        "marker_size": marker_size,
+        "squares_x": squares_x,
+        "squares_y": squares_y
+    }
+
+    intrinsics_path = os.path.join(data_path, f"{os.path.basename(data_path)}_camera_intrinsics.json")
+    with open(intrinsics_path, "w") as f:
+        json.dump(calib_data, f, indent=4)
+
+    print(f"Intrinsics saved to {intrinsics_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-c",
+        "--camera",
+        type=str,
+        required=True,
+        choices=CAMERA_CONFIG.keys(),
+        help="Which camera: scene, tool_front_right, tool_front_left, tool_right, tool_left",
+    )
+    parser.add_argument(
+        "-p",
+        "--path",
+        type=str,
+        default=None,
+        help="Optional path to calibration data folder",
+    )
+    args = parser.parse_args()
+
+    if args.path:
+        data_path = os.path.join(os.path.expanduser(args.path), args.camera)
+    else:
+        data_path = os.path.expanduser(f"~/ceai_ws/calibration_data/{args.camera}")
+
+    calibrate_intrinsics(data_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/aegis_utils/aegis_utils/calib_intrinsics.py
+++ b/aegis_utils/aegis_utils/calib_intrinsics.py
@@ -14,7 +14,7 @@ CAMERA_CONFIG = {
     "scene": {},
 }
 
-def calibrate_intrinsics(data_path):
+def calibrate_intrinsics(data_path: str) -> None:
     squares_x = 9
     squares_y = 6
     square_size = 0.03
@@ -81,7 +81,7 @@ def calibrate_intrinsics(data_path):
     print(f"Intrinsics saved to {intrinsics_path}")
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-c",

--- a/aegis_utils/aegis_utils/calib_intrinsics.py
+++ b/aegis_utils/aegis_utils/calib_intrinsics.py
@@ -14,6 +14,7 @@ CAMERA_CONFIG = {
     "scene": {},
 }
 
+
 def calibrate_intrinsics(data_path: str) -> None:
     squares_x = 9
     squares_y = 6
@@ -21,7 +22,9 @@ def calibrate_intrinsics(data_path: str) -> None:
     marker_size = 0.022
 
     aruco_dict = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_6X6_1000)
-    board = cv2.aruco.CharucoBoard((squares_x, squares_y), square_size, marker_size, aruco_dict)
+    board = cv2.aruco.CharucoBoard(
+        (squares_x, squares_y), square_size, marker_size, aruco_dict
+    )
     board.setLegacyPattern(True)
 
     images = natsorted(glob.glob(os.path.join(os.path.expanduser(data_path), "*.png")))
@@ -41,8 +44,12 @@ def calibrate_intrinsics(data_path: str) -> None:
 
         corners, ids, _ = cv2.aruco.detectMarkers(img_gray, aruco_dict)
         if ids is not None and len(ids) > 0:
-            retval, charuco_corners, charuco_ids = cv2.aruco.interpolateCornersCharuco(corners, ids, img_gray, board)
-            print(f"{retval} ChArUco corners were detected in image {os.path.basename(fname)}")
+            retval, charuco_corners, charuco_ids = cv2.aruco.interpolateCornersCharuco(
+                corners, ids, img_gray, board
+            )
+            print(
+                f"{retval} ChArUco corners were detected in image {os.path.basename(fname)}"
+            )
             if charuco_ids is not None and len(charuco_ids) > 3:
                 all_corners.append(charuco_corners)
                 all_ids.append(charuco_ids)
@@ -59,7 +66,7 @@ def calibrate_intrinsics(data_path: str) -> None:
         board=board,
         imageSize=image_size,
         cameraMatrix=None,
-        distCoeffs=None
+        distCoeffs=None,
     )
 
     print("Camera matrix (K):\n", camera_matrix)
@@ -71,10 +78,12 @@ def calibrate_intrinsics(data_path: str) -> None:
         "square_size": square_size,
         "marker_size": marker_size,
         "squares_x": squares_x,
-        "squares_y": squares_y
+        "squares_y": squares_y,
     }
 
-    intrinsics_path = os.path.join(data_path, f"{os.path.basename(data_path)}_camera_intrinsics.json")
+    intrinsics_path = os.path.join(
+        data_path, f"{os.path.basename(data_path)}_camera_intrinsics.json"
+    )
     with open(intrinsics_path, "w") as f:
         json.dump(calib_data, f, indent=4)
 

--- a/aegis_utils/aegis_utils/calib_intrinsics.py
+++ b/aegis_utils/aegis_utils/calib_intrinsics.py
@@ -17,7 +17,12 @@ CAMERA_CONFIG = {
 
 
 def calibrate_intrinsics(
-    data_path: Path, squares_x, squares_y, square_size, marker_size, aruco_dict
+    data_path: Path,
+    squares_x: int,
+    squares_y: int,
+    square_size: float,
+    marker_size: float,
+    aruco_dict: cv2.aruco_Dictionary,
 ) -> None:
     board = cv2.aruco.CharucoBoard(
         (squares_x, squares_y),

--- a/aegis_utils/aegis_utils/calib_intrinsics.py
+++ b/aegis_utils/aegis_utils/calib_intrinsics.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import cv2
 from natsort import natsorted
+import yaml
+
 
 CAMERA_CONFIG = {
     "tool_front_right": {},
@@ -14,20 +16,18 @@ CAMERA_CONFIG = {
 }
 
 
-def calibrate_intrinsics(data_path: Path) -> None:
-    squares_x = 9
-    squares_y = 6
-    square_size = 0.03
-    marker_size = 0.022
-
-    aruco_dict = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_6X6_1000)
+def calibrate_intrinsics(
+    data_path: Path, squares_x, squares_y, square_size, marker_size, aruco_dict
+) -> None:
     board = cv2.aruco.CharucoBoard(
-        (squares_x, squares_y), square_size, marker_size, aruco_dict
+        (squares_x, squares_y),
+        square_size,
+        marker_size,
+        aruco_dict,
     )
     board.setLegacyPattern(True)
 
     image_paths = natsorted(data_path.glob("*_image_*.png"))
-
     if not image_paths:
         print(f"No images found in {data_path}")
         return
@@ -46,16 +46,14 @@ def calibrate_intrinsics(data_path: Path) -> None:
             retval, charuco_corners, charuco_ids = cv2.aruco.interpolateCornersCharuco(
                 corners, ids, img_gray, board
             )
-            print(
-                f"{retval} ChArUco corners were detected in image {image_path.name}"
-            )
+            print(f"{retval} ChArUco corners were detected in image {image_path.name}")
             if charuco_ids is not None and len(charuco_ids) > 3:
                 all_corners.append(charuco_corners)
                 all_ids.append(charuco_ids)
 
     print(f"Found {len(all_corners)} valid images for calibration")
 
-    if len(all_corners) == 0:
+    if not all_corners:
         print("No valid data for calibration")
         return
 
@@ -111,7 +109,26 @@ def main() -> None:
     else:
         data_path = Path("~/ceai_ws/calibration_data").expanduser() / args.camera
 
-    calibrate_intrinsics(data_path)
+    board_path = Path(__file__).parent.parent / "config" / "charuco_board.yaml"
+    with open(board_path, "r") as f:
+        board_cfg = yaml.safe_load(f)
+
+    if args.camera.startswith("tool"):
+        board_params = board_cfg["tool_camera"]
+    else:
+        board_params = board_cfg["scene_camera"]
+
+    squares_x = board_params["squares_x"]
+    squares_y = board_params["squares_y"]
+    square_size = board_params["square_size"]
+    marker_size = board_params["marker_size"]
+    aruco_dict = cv2.aruco.getPredefinedDictionary(
+        getattr(cv2.aruco, board_params["aruco_dict"])
+    )
+
+    calibrate_intrinsics(
+        data_path, squares_x, squares_y, square_size, marker_size, aruco_dict
+    )
 
 
 if __name__ == "__main__":

--- a/aegis_utils/aegis_utils/calib_intrinsics.py
+++ b/aegis_utils/aegis_utils/calib_intrinsics.py
@@ -119,9 +119,9 @@ def main() -> None:
         board_cfg = yaml.safe_load(f)
 
     if args.camera.startswith("tool"):
-        board_params = board_cfg["tool_camera"]
+        board_params = board_cfg["tool"]
     else:
-        board_params = board_cfg["scene_camera"]
+        board_params = board_cfg["scene"]
 
     squares_x = board_params["squares_x"]
     squares_y = board_params["squares_y"]

--- a/aegis_utils/config/charuco_board.yaml
+++ b/aegis_utils/config/charuco_board.yaml
@@ -1,0 +1,13 @@
+tool:
+  squares_x: 9
+  squares_y: 6
+  square_size: 0.03
+  marker_size: 0.022
+  aruco_dict: DICT_6X6_1000
+
+scene:
+  squares_x: 7
+  squares_y: 4
+  square_size: 0.02
+  marker_size: 0.015
+  aruco_dict: DICT_4X4_1000

--- a/aegis_utils/setup.py
+++ b/aegis_utils/setup.py
@@ -16,6 +16,7 @@ setup(
                 "config/cam_tool_front.yaml",
                 "config/cam_tool_right.yaml",
                 "config/cam_tool_left.yaml",
+                "config/charuco_board.yaml",
             ],
         ),
     ],

--- a/aegis_utils/setup.py
+++ b/aegis_utils/setup.py
@@ -28,6 +28,7 @@ setup(
     entry_points={
         "console_scripts": [
             "calib_data_collect = aegis_utils.calib_data_collect:main",
+            "calib_intrinsics = aegis_utils.calib_intrinsics:main",
         ],
     },
 )


### PR DESCRIPTION
## Description
This PR adds a script to compute the intrinsic parameters of a camera using previously collected calibration images. 
The program processes a set of ChArUco pattern images and saves the resulting camera matrix and distortion coefficients. 


## Motivation and context
This utility standardizes and automates the computation of camera intrinsic parameters, making the calibration workflow more consistent and reproducible.


## How has this been tested?
Manually, by running the script.


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
[Clickup](https://app.clickup.com/t/8699kmacx)