### PR TITLE
Fix typos from hande_description

### DIFF
--- a/aegis_description/CHANGELOG.md
+++ b/aegis_description/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* [PR-52](https://github.com/AGH-CEAI/aegis_ros/pull/52) - Renamed `ip_adress` to `socat_ip_address` and `port` to `socat_port`.
 * [PR-49](https://github.com/AGH-CEAI/aegis_ros/pull/49) - Updated Hand-E gripper parameters.
 * [PR-44](https://github.com/AGH-CEAI/aegis_ros/pull/44) - Updated adapter to sensor component and SCHUNK AXIA 80 F/T sensor.
 * [PR-43](https://github.com/AGH-CEAI/aegis_ros/pull/43) - Updated adapter to sensor component.

--- a/aegis_description/urdf/modules/robotiq_hande_gripper.xacro
+++ b/aegis_description/urdf/modules/robotiq_hande_gripper.xacro
@@ -11,8 +11,8 @@
   <xacro:arg name="frequency_hz" default="100"/>
 
   <xacro:arg name="create_socat_tty" default="true"/>
-  <xacro:arg name="ip_adress" default="aegis_ur"/>
-  <xacro:arg name="port" default="54321"/>
+  <xacro:arg name="socat_ip_address" default="aegis_ur"/>
+  <xacro:arg name="socat_port" default="54321"/>
 
   <xacro:include filename="$(find robotiq_hande_description)/urdf/robotiq_hande_gripper.xacro"/>
 
@@ -32,8 +32,8 @@
       slave_id="$(arg slave_id)"
       frequency_hz="$(arg frequency_hz)"
       create_socat_tty="$(arg create_socat_tty)"
-      ip_adress="$(arg ip_adress)"
-      port="$(arg port)"
+      socat_ip_address="$(arg socat_ip_address)"
+      socat_port="$(arg socat_port)"
       use_fake_hardware="${mock_hardware}"
     />
   </xacro:macro>


### PR DESCRIPTION
## Description
This PR fixes a typo in a variable from `ip_adress` to `socat_ip_address` and `port` to `socat_port`.


## Motivation and context
The typo in the `socat_ip_address` variable was fixed in [PR #23](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/27) in the [robotiq_hande_driver](https://github.com/AGH-CEAI/robotiq_hande_driver) repository. Correcting this ensures consistency and avoids potential runtime errors when specifying the IP address for TCP connections.


## How has this been tested?
Manually, on the Geonosis PC.


## Related PRs
* https://github.com/AGH-CEAI/robotiq_hande_driver/pull/27
* https://github.com/AGH-CEAI/robotiq_hande_description/pull/15


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed. 

---

Clickup Task: [869a6nn34](https://app.clickup.com/t/869a6nn34)