### PR TITLE
Integrate all UR controllers

### DIFF
--- a/aegis_bringup/CHANGELOG.md
+++ b/aegis_bringup/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+* [PR-60](https://github.com/AGH-CEAI/aegis_ros/pull/60) - Updated launch files diagram.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/aegis_bringup/docs/launch_diagram.plantuml
+++ b/aegis_bringup/docs/launch_diagram.plantuml
@@ -106,8 +106,9 @@ package aegis_moveit_config {
     package config {
         class aegis << (S,#c298e9) SRDF >> {}
         package move_group {
-            class ompl_planning << (Y,#ffffc9) YAML >> {}
             class kinematics << (Y,#ffffc9) YAML >> {}
+            class ompl_planning << (Y,#ffffc9) YAML >> {}
+            class planning_joint_limits << (Y,#ffffc9) YAML >> {}
         }
         class moveit << (R,#ffffff) rviz >> {}
         class controlers_description << (Y,#ffffc9) YAML >> {}

--- a/aegis_control/CHANGELOG.md
+++ b/aegis_control/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+* [PR-60](https://github.com/AGH-CEAI/aegis_ros/pull/60) - Enabled all UR driver controllers.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/aegis_control/config/controllers/ur_drivers.yaml
+++ b/aegis_control/config/controllers/ur_drivers.yaml
@@ -9,38 +9,41 @@
       joint_state_broadcaster:
         type: joint_state_broadcaster/JointStateBroadcaster
 
-      io_and_status_controller:
-        type: ur_controllers/GPIOController
-
       speed_scaling_state_broadcaster:
         type: ur_controllers/SpeedScalingStateBroadcaster
+
+      tcp_pose_broadcaster:
+        type: pose_broadcaster/PoseBroadcaster
 
       ur_force_torque_sensor_broadcaster:
         type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
 
-      joint_trajectory_controller:
-        type: joint_trajectory_controller/JointTrajectoryController
-
-      scaled_joint_trajectory_controller:
-        type: ur_controllers/ScaledJointTrajectoryController
-
-      forward_velocity_controller:
-        type: velocity_controllers/JointGroupVelocityController
+      force_mode_controller:
+        type: ur_controllers/ForceModeController
 
       forward_position_controller:
         type: position_controllers/JointGroupPositionController
 
-      force_mode_controller:
-        type: ur_controllers/ForceModeController
+      forward_velocity_controller:
+        type: velocity_controllers/JointGroupVelocityController
 
       freedrive_mode_controller:
         type: ur_controllers/FreedriveModeController
 
+      io_and_status_controller:
+        type: ur_controllers/GPIOController
+
+      joint_trajectory_controller:
+        type: joint_trajectory_controller/JointTrajectoryController
+
       passthrough_trajectory_controller:
         type: ur_controllers/PassthroughTrajectoryController
 
-      tcp_pose_broadcaster:
-        type: pose_broadcaster/PoseBroadcaster
+      scaled_joint_trajectory_controller:
+        type: ur_controllers/ScaledJointTrajectoryController
+
+      tool_contact_controller:
+        type: ur_controllers/ToolContactController
 
       ur_configuration_controller:
         type: ur_controllers/URConfigurationController
@@ -50,13 +53,12 @@
       state_publish_rate: 100.0
       tf_prefix: "$(var tf_prefix)"
 
-  io_and_status_controller:
+  tcp_pose_broadcaster:
     ros__parameters:
-      tf_prefix: "$(var tf_prefix)"
-
-  ur_configuration_controller:
-    ros__parameters:
-      tf_prefix: "$(var tf_prefix)"
+      frame_id: $(var tf_prefix)base
+      pose_name: $(var tf_prefix)tcp_pose
+      tf:
+        child_frame_id: $(var tf_prefix)tool0_controller
 
   ur_force_torque_sensor_broadcaster:
     ros__parameters:
@@ -70,6 +72,39 @@
         - torque.z
       frame_id: $(var tf_prefix)tool0
       topic_name: ft_data
+
+  force_mode_controller:
+    ros__parameters:
+      tf_prefix: "$(var tf_prefix)"
+
+  forward_position_controller:
+    ros__parameters:
+      joints:
+        - $(var tf_prefix)shoulder_pan_joint
+        - $(var tf_prefix)shoulder_lift_joint
+        - $(var tf_prefix)elbow_joint
+        - $(var tf_prefix)wrist_1_joint
+        - $(var tf_prefix)wrist_2_joint
+        - $(var tf_prefix)wrist_3_joint
+
+  forward_velocity_controller:
+    ros__parameters:
+      joints:
+        - $(var tf_prefix)shoulder_pan_joint
+        - $(var tf_prefix)shoulder_lift_joint
+        - $(var tf_prefix)elbow_joint
+        - $(var tf_prefix)wrist_1_joint
+        - $(var tf_prefix)wrist_2_joint
+        - $(var tf_prefix)wrist_3_joint
+      interface_name: velocity
+
+  freedrive_mode_controller:
+    ros__parameters:
+      tf_prefix: "$(var tf_prefix)"
+
+  io_and_status_controller:
+    ros__parameters:
+      tf_prefix: "$(var tf_prefix)"
 
   joint_trajectory_controller:
     ros__parameters:
@@ -97,6 +132,21 @@
         $(var tf_prefix)wrist_1_joint: { trajectory: 0.2, goal: 0.1 }
         $(var tf_prefix)wrist_2_joint: { trajectory: 0.2, goal: 0.1 }
         $(var tf_prefix)wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
+
+  passthrough_trajectory_controller:
+    ros__parameters:
+      tf_prefix: "$(var tf_prefix)"
+      joints:
+        - $(var tf_prefix)shoulder_pan_joint
+        - $(var tf_prefix)shoulder_lift_joint
+        - $(var tf_prefix)elbow_joint
+        - $(var tf_prefix)wrist_1_joint
+        - $(var tf_prefix)wrist_2_joint
+        - $(var tf_prefix)wrist_3_joint
+      state_interfaces:
+        - position
+        - velocity
+      speed_scaling_interface_name: $(var tf_prefix)speed_scaling/speed_scaling_factor
 
   scaled_joint_trajectory_controller:
     ros__parameters:
@@ -126,53 +176,10 @@
         $(var tf_prefix)wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
       speed_scaling_interface_name: $(var tf_prefix)speed_scaling/speed_scaling_factor
 
-  passthrough_trajectory_controller:
-    ros__parameters:
-      tf_prefix: "$(var tf_prefix)"
-      joints:
-        - $(var tf_prefix)shoulder_pan_joint
-        - $(var tf_prefix)shoulder_lift_joint
-        - $(var tf_prefix)elbow_joint
-        - $(var tf_prefix)wrist_1_joint
-        - $(var tf_prefix)wrist_2_joint
-        - $(var tf_prefix)wrist_3_joint
-      state_interfaces:
-        - position
-        - velocity
-      speed_scaling_interface_name: $(var tf_prefix)speed_scaling/speed_scaling_factor
-
-  forward_velocity_controller:
-    ros__parameters:
-      joints:
-        - $(var tf_prefix)shoulder_pan_joint
-        - $(var tf_prefix)shoulder_lift_joint
-        - $(var tf_prefix)elbow_joint
-        - $(var tf_prefix)wrist_1_joint
-        - $(var tf_prefix)wrist_2_joint
-        - $(var tf_prefix)wrist_3_joint
-      interface_name: velocity
-
-  forward_position_controller:
-    ros__parameters:
-      joints:
-        - $(var tf_prefix)shoulder_pan_joint
-        - $(var tf_prefix)shoulder_lift_joint
-        - $(var tf_prefix)elbow_joint
-        - $(var tf_prefix)wrist_1_joint
-        - $(var tf_prefix)wrist_2_joint
-        - $(var tf_prefix)wrist_3_joint
-
-  force_mode_controller:
+  tool_contact_controller:
     ros__parameters:
       tf_prefix: "$(var tf_prefix)"
 
-  freedrive_mode_controller:
+  ur_configuration_controller:
     ros__parameters:
       tf_prefix: "$(var tf_prefix)"
-
-  tcp_pose_broadcaster:
-    ros__parameters:
-      frame_id: $(var tf_prefix)base
-      pose_name: $(var tf_prefix)tcp_pose
-      tf:
-        child_frame_id: $(var tf_prefix)tool0_controller

--- a/aegis_control/launch/ur_driver.launch.py
+++ b/aegis_control/launch/ur_driver.launch.py
@@ -48,7 +48,7 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         "io_and_status_controller",
         "speed_scaling_state_broadcaster",
         "ur_force_torque_sensor_broadcaster",
-        "tcp_pose_broadcaster",  # TODO(issue#12): debug why this doesn't work
+        "tcp_pose_broadcaster",
         "ur_configuration_controller",
     ]
     controllers_inactive = [
@@ -56,7 +56,6 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         "joint_trajectory_controller",
         "forward_velocity_controller",
         "forward_position_controller",
-        # TODO(issue#12): debug why these controllers don't work
         "force_mode_controller",
         "passthrough_trajectory_controller",
         "freedrive_mode_controller",

--- a/aegis_control/launch/ur_driver.launch.py
+++ b/aegis_control/launch/ur_driver.launch.py
@@ -48,7 +48,7 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         "io_and_status_controller",
         "speed_scaling_state_broadcaster",
         "ur_force_torque_sensor_broadcaster",
-        # "tcp_pose_broadcaster", # TODO(issue#12): debug why this doesn't work
+        "tcp_pose_broadcaster",  # TODO(issue#12): debug why this doesn't work
         "ur_configuration_controller",
     ]
     controllers_inactive = [
@@ -57,9 +57,10 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         "forward_velocity_controller",
         "forward_position_controller",
         # TODO(issue#12): debug why these controllers don't work
-        # "force_mode_controller",
-        # "passthrough_trajectory_controller",
-        # "freedrive_mode_controller",
+        "force_mode_controller",
+        "passthrough_trajectory_controller",
+        "freedrive_mode_controller",
+        "tool_contact_controller",
     ]
 
     init_joint_controller = (
@@ -69,6 +70,9 @@ def launch_setup(context: LaunchContext) -> list[Node]:
     )
     controllers_active.append(init_joint_controller)
     controllers_inactive.remove(init_joint_controller)
+
+    if mock_hardware_bool:
+        controllers_active.remove("tcp_pose_broadcaster")
 
     return [
         tool_communication_node,
@@ -136,6 +140,7 @@ def prepare_controller_stopper_node(mock_hardware: LaunchConfiguration) -> Node:
                     "force_torque_sensor_broadcaster",
                     "joint_state_broadcaster",
                     "speed_scaling_state_broadcaster",
+                    "tcp_pose_broadcaster",
                     "ur_configuration_controller",
                 ]
             },

--- a/aegis_description/CHANGELOG.md
+++ b/aegis_description/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 
+* [PR-60](https://github.com/AGH-CEAI/aegis_ros/pull/60) - Decreased the default velocity and acceleration scaling factor to 5%.
 * [PR-57](https://github.com/AGH-CEAI/aegis_ros/pull/57) - Increased the position limit of the wrist 1 joint.
 
 ### Deprecated

--- a/aegis_description/config/ur5e/joint_limits.yaml
+++ b/aegis_description/config/ur5e/joint_limits.yaml
@@ -10,8 +10,8 @@
 
 # For beginners, we downscale velocity and acceleration limits.
 # You can always specify higher scaling factors (<= 1.0) in your motion requests.  # Increase the values below to 1.0 to always move at maximum speed.
-default_velocity_scaling_factor: 0.1
-default_acceleration_scaling_factor: 0.1
+default_velocity_scaling_factor: 0.05
+default_acceleration_scaling_factor: 0.05
 
 joint_limits:
   shoulder_pan_joint:

--- a/aegis_moveit_config/CHANGELOG.md
+++ b/aegis_moveit_config/CHANGELOG.md
@@ -8,7 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+* [PR-60](https://github.com/AGH-CEAI/aegis_ros/pull/60) - Added maximum acceleration limits config for Moveit planning.
+
 ### Changed
+
+
+* [PR-60](https://github.com/AGH-CEAI/aegis_ros/pull/60) - Disabled MoveIt's Trajectory Execution Monitoring (TEM) - it is now possible to scale down robot speeds without trajectory errors.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/aegis_moveit_config/config/move_group/planning_joint_limits.yaml
+++ b/aegis_moveit_config/config/move_group/planning_joint_limits.yaml
@@ -1,0 +1,26 @@
+# Source: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/blob/humble/ur_moveit_config/config/joint_limits.yaml
+# These limits are used by MoveIt and augment/override the definitions in ur_description.
+#
+# While the robot does not inherently have any limits on joint accelerations (only on torques),
+# MoveIt needs them for time parametrization. They were chosen conservatively to work in most use
+# cases. For specific applications, higher values might lead to better execution performance.
+
+joint_limits:
+  shoulder_pan_joint:
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  shoulder_lift_joint:
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  elbow_joint:
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  wrist_1_joint:
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  wrist_2_joint:
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  wrist_3_joint:
+    has_acceleration_limits: true
+    max_acceleration: 5.0

--- a/aegis_moveit_config/config/moveit.rviz
+++ b/aegis_moveit_config/config/moveit.rviz
@@ -60,7 +60,7 @@ Visualization Manager:
       Update Interval: 0
       Value: false
       Visual Enabled: true
-    - Acceleration_Scaling_Factor: 0.1
+    - Acceleration_Scaling_Factor: 0.05
       Class: moveit_rviz_plugin/MotionPlanning
       Enabled: true
       Move Group Namespace: ""
@@ -645,7 +645,7 @@ Visualization Manager:
         Show Robot Collision: false
         Show Robot Visual: true
       Value: true
-      Velocity_Scaling_Factor: 0.1
+      Velocity_Scaling_Factor: 0.05
     - Class: rviz_default_plugins/TF
       Enabled: false
       Frame Timeout: 15

--- a/aegis_moveit_config/launch/move_group.launch.py
+++ b/aegis_moveit_config/launch/move_group.launch.py
@@ -104,6 +104,10 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         "trajectory_execution.allowed_execution_duration_scaling": 1.2,
         "trajectory_execution.allowed_goal_duration_margin": 0.5,
         "trajectory_execution.allowed_start_tolerance": 0.01,
+        # UR Driver is not compatible with the MoveIt's Trajectory Execution Monitoring (TEM) 
+        # See # https://docs.universal-robots.com/Universal_Robots_ROS2_Documentation/doc/ur_robot_driver/ur_moveit_config/doc/index.html#id2
+        # Execution time monitoring can be incompatible with the scaled JTC
+        "trajectory_execution.execution_duration_monitoring": False,
     }
 
     planning_scene_monitor_parameters = {

--- a/aegis_moveit_config/launch/move_group.launch.py
+++ b/aegis_moveit_config/launch/move_group.launch.py
@@ -58,6 +58,9 @@ class AegisPathsCfg:
 
     def load_joint_limits_cfg(self) -> dict:
         return load_yaml(self.description_cfg_pkg_name, "config/ur5e/joint_limits.yaml")
+    
+    def load_planning_joint_limits_cfg(self) -> dict:
+        return load_yaml(self.moveit_cfg_pkg_name, "config/move_group/planning_joint_limits.yaml")
 
     def load_octomap_updater_cfg(self) -> dict:
         return load_yaml(self.moveit_cfg_pkg_name, "config/octomap_updater.yaml")
@@ -77,9 +80,8 @@ def launch_setup(context: LaunchContext) -> list[Node]:
 
     mock_hardware_bool = str2bool(context.perform_substitution(mock_hardware))
 
-    robot_description_planning = {
-        "robot_description_planning": paths.load_joint_limits_cfg()
-    }
+    # Planning joints limits
+    robot_description_planning = get_robot_description_planning(paths) 
 
     # Planning Configuration
     ompl_planning_pipeline_cfg = paths.load_ompl_planning_cfg()
@@ -160,6 +162,13 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         # servo_node(),
     ]
 
+def get_robot_description_planning(paths: AegisPathsCfg) -> dict:
+    return {
+        "robot_description_planning": {
+            **paths.load_joint_limits_cfg(),
+            **paths.load_planning_joint_limits_cfg(),
+        }
+    }
 
 def get_robot_description_semantic(paths: AegisPathsCfg) -> dict:
     robot_description_semantic_content = Command(

--- a/aegis_moveit_config/launch/move_group.launch.py
+++ b/aegis_moveit_config/launch/move_group.launch.py
@@ -16,6 +16,14 @@ from ur_moveit_config.launch_common import load_yaml
 def str2bool(x: str) -> bool:
     return x.lower() in ("true")
 
+def deep_dict_update(d_target: dict, d_update: dict) -> dict:
+    for k, v in d_update.items():
+        if (k in d_target and isinstance(d_target[k], dict) and isinstance(v, dict)):
+            deep_dict_update(d_target[k], v)
+        else:
+            d_target[k] = v
+    return d_target
+
 
 class AegisPathsCfg:
     """Contains paths to the configuration files."""
@@ -81,7 +89,13 @@ def launch_setup(context: LaunchContext) -> list[Node]:
     mock_hardware_bool = str2bool(context.perform_substitution(mock_hardware))
 
     # Planning joints limits
-    robot_description_planning = get_robot_description_planning(paths) 
+    robot_description_planning = {
+        "robot_description_planning": deep_dict_update(
+            paths.load_joint_limits_cfg(),
+            paths.load_planning_joint_limits_cfg(),
+        )
+    }
+
 
     # Planning Configuration
     ompl_planning_pipeline_cfg = paths.load_ompl_planning_cfg()
@@ -165,14 +179,6 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         # TODO(issue#5) enable real-time servo
         # servo_node(),
     ]
-
-def get_robot_description_planning(paths: AegisPathsCfg) -> dict:
-    return {
-        "robot_description_planning": {
-            **paths.load_joint_limits_cfg(),
-            **paths.load_planning_joint_limits_cfg(),
-        }
-    }
 
 def get_robot_description_semantic(paths: AegisPathsCfg) -> dict:
     robot_description_semantic_content = Command(

--- a/aegis_moveit_config/launch/move_group.launch.py
+++ b/aegis_moveit_config/launch/move_group.launch.py
@@ -16,9 +16,10 @@ from ur_moveit_config.launch_common import load_yaml
 def str2bool(x: str) -> bool:
     return x.lower() in ("true")
 
+
 def deep_dict_update(d_target: dict, d_update: dict) -> dict:
     for k, v in d_update.items():
-        if (k in d_target and isinstance(d_target[k], dict) and isinstance(v, dict)):
+        if k in d_target and isinstance(d_target[k], dict) and isinstance(v, dict):
             deep_dict_update(d_target[k], v)
         else:
             d_target[k] = v
@@ -66,9 +67,11 @@ class AegisPathsCfg:
 
     def load_joint_limits_cfg(self) -> dict:
         return load_yaml(self.description_cfg_pkg_name, "config/ur5e/joint_limits.yaml")
-    
+
     def load_planning_joint_limits_cfg(self) -> dict:
-        return load_yaml(self.moveit_cfg_pkg_name, "config/move_group/planning_joint_limits.yaml")
+        return load_yaml(
+            self.moveit_cfg_pkg_name, "config/move_group/planning_joint_limits.yaml"
+        )
 
     def load_octomap_updater_cfg(self) -> dict:
         return load_yaml(self.moveit_cfg_pkg_name, "config/octomap_updater.yaml")
@@ -96,7 +99,6 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         )
     }
 
-
     # Planning Configuration
     ompl_planning_pipeline_cfg = paths.load_ompl_planning_cfg()
 
@@ -118,7 +120,7 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         "trajectory_execution.allowed_execution_duration_scaling": 1.2,
         "trajectory_execution.allowed_goal_duration_margin": 0.5,
         "trajectory_execution.allowed_start_tolerance": 0.01,
-        # UR Driver is not compatible with the MoveIt's Trajectory Execution Monitoring (TEM) 
+        # UR Driver is not compatible with the MoveIt's Trajectory Execution Monitoring (TEM)
         # See # https://docs.universal-robots.com/Universal_Robots_ROS2_Documentation/doc/ur_robot_driver/ur_moveit_config/doc/index.html#id2
         # Execution time monitoring can be incompatible with the scaled JTC
         "trajectory_execution.execution_duration_monitoring": False,
@@ -179,6 +181,7 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         # TODO(issue#5) enable real-time servo
         # servo_node(),
     ]
+
 
 def get_robot_description_semantic(paths: AegisPathsCfg) -> dict:
     robot_description_semantic_content = Command(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* It closes #12 , the updated ros-humble packages didn't have any problems with the "new" UR driver controllers:
  *  `force_mode_controller`
  *  `passthrough_trajectory_controller`
  *  `freedrive_mode_controller`
  *  `tool_contact_controller`
  *   `tcp_pose_broadcaster`
* By adding a [one liner to disable MoveIt2's TEM](https://docs.universal-robots.com/Universal_Robots_ROS2_Documentation/doc/ur_robot_driver/ur_moveit_config/doc/index.html) it is now possible to use the scaled down velocities for planning :yo_yo: .

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Enable all controllers before enabling the servo.

<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually, by controlling the real robot from RViz.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [8698rrr1r](https://app.clickup.com/t/8698rrr1r)
Clickup task: [869aa101r](https://app.clickup.com/t/869aa101r)
