### PR TITLE
Change cell collision

### DIFF
--- a/aegis_description/CHANGELOG.md
+++ b/aegis_description/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 
+* [PR-62](https://github.com/AGH-CEAI/aegis_ros/pull/62) - Replaced cell collision mesh with primitive shapes.
 * [PR-60](https://github.com/AGH-CEAI/aegis_ros/pull/60) - Decreased the default velocity and acceleration scaling factor to 5%.
 * [PR-57](https://github.com/AGH-CEAI/aegis_ros/pull/57) - Increased the position limit of the wrist 1 joint.
 

--- a/aegis_description/urdf/modules/cell.xacro
+++ b/aegis_description/urdf/modules/cell.xacro
@@ -15,9 +15,33 @@
         </geometry>
       </visual>
       <collision>
-        <origin xyz="-0.460 -0.240 0.786" rpy="0 0 0"/>
+        <origin xyz="0 0.06 0.43" rpy="0 0 0"/>
         <geometry>
-          <mesh filename="package://aegis_description/meshes/cell.dae" scale="1.0 1.0 1.0"/>
+          <box size="0.84 0.56 0.86"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="-0.48 0 0.96" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.12 0.68 1.92"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0.48 0 0.96" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.12 0.68 1.92"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0 -0.28 0.96" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.84 0.12 1.92"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0 0.04 1.98" rpy="0 0 0"/>
+        <geometry>
+          <box size="1.08 0.76 0.12"/>
         </geometry>
       </collision>
     </link>

--- a/aegis_description/urdf/modules/cell.xacro
+++ b/aegis_description/urdf/modules/cell.xacro
@@ -15,33 +15,39 @@
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 0.06 0.43" rpy="0 0 0"/>
+        <origin xyz="0 0 0.41" rpy="0 0 0"/>
         <geometry>
-          <box size="0.84 0.56 0.86"/>
+          <box size="0.88 0.648 0.82"/>
         </geometry>
       </collision>
       <collision>
-        <origin xyz="-0.48 0 0.96" rpy="0 0 0"/>
+        <origin xyz="0.48 0 0.97" rpy="0 0 0"/>
         <geometry>
-          <box size="0.12 0.68 1.92"/>
+          <box size="0.08 0.648 1.94"/>
         </geometry>
       </collision>
       <collision>
-        <origin xyz="0.48 0 0.96" rpy="0 0 0"/>
+        <origin xyz="0.41 0 0.85" rpy="0 0 0"/>
         <geometry>
-          <box size="0.12 0.68 1.92"/>
+          <box size="0.06 0.648 0.06"/>
         </geometry>
       </collision>
       <collision>
-        <origin xyz="0 -0.28 0.96" rpy="0 0 0"/>
+        <origin xyz="-0.48 0 0.97" rpy="0 0 0"/>
         <geometry>
-          <box size="0.84 0.12 1.92"/>
+          <box size="0.08 0.648 1.94"/>
         </geometry>
       </collision>
       <collision>
-        <origin xyz="0 0.04 1.98" rpy="0 0 0"/>
+        <origin xyz="-0.41 0 0.85" rpy="0 0 0"/>
         <geometry>
-          <box size="1.08 0.76 0.12"/>
+          <box size="0.06 0.648 0.06"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0 0.02 1.98" rpy="0 0 0"/>
+        <geometry>
+          <box size="1.04 0.688 0.08"/>
         </geometry>
       </collision>
     </link>

--- a/aegis_description/urdf/modules/cell.xacro
+++ b/aegis_description/urdf/modules/cell.xacro
@@ -45,9 +45,9 @@
         </geometry>
       </collision>
       <collision>
-        <origin xyz="0 0.02 1.98" rpy="0 0 0"/>
+        <origin xyz="0 0.04 1.98" rpy="0 0 0"/>
         <geometry>
-          <box size="1.04 0.688 0.08"/>
+          <box size="1.04 0.728 0.08"/>
         </geometry>
       </collision>
     </link>


### PR DESCRIPTION
## Description
This PR replaces the collision mesh in the cell URDF with a set of simple primitive shapes (boxes).

## Motivation and context
Using primitive shapes for collision instead of a detailed visual mesh improves simulation performance by making collision checks faster and more stable. In practical applications, it also helps the robot maintain a safer margin around the structure.


## Screenshots
<img width="864" height="1195" alt="screen" src="https://github.com/user-attachments/assets/c1369e4e-3bfb-4738-b4f6-d30cb99892f8" />


## How has this been tested?
In RViz.

## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.