### PR TITLE
Add calibration TF

### DIFF
--- a/aegis_control/CHANGELOG.md
+++ b/aegis_control/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+* [PR-65](https://github.com/AGH-CEAI/aegis_ros/pull/65) - Added static transformation nodes for cameras from calibration.
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -1,6 +1,8 @@
 import json
 import tempfile
+import time
 from pathlib import Path
+from typing import Dict
 
 import numpy as np
 import yaml
@@ -11,6 +13,7 @@ from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration, TextSubstitution
 from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes, Node
 from launch_ros.descriptions import ComposableNode
+from rclpy.logging import get_logger
 from scipy.spatial.transform import Rotation
 
 
@@ -139,15 +142,38 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         }
     }
 
-    cam_scene_extrinsics_path = Path(
-        "~/ceai_ws/src/aegis_ros/aegis_utils/config/scene_extrinsics.yaml"
-    ).expanduser()
-    cam_tool_front_right_extrinsics_path = Path(
-        "~/ceai_ws/src/aegis_ros/aegis_utils/config/tool_front_right_extrinsics.yaml"
-    ).expanduser()
-    cam_tool_front_left_extrinsics_path = Path(
-        "~/ceai_ws/src/aegis_ros/aegis_utils/config/tool_front_left_extrinsics.yaml"
-    ).expanduser()
+    logger = get_logger("depthai_cameras_driver")
+
+    calibration_extrinsics_paths = {
+        "cam_scene_rgb": Path(
+            "~/ceai_ws/src/aegis_ros/aegis_utils/config/scene_extrinsics.yaml"
+        ).expanduser(),
+        "cam_tool_front_right": Path(
+            "~/ceai_ws/src/aegis_ros/aegis_utils/config/tool_front_right_extrinsics.yaml"
+        ).expanduser(),
+        "cam_tool_front_left": Path(
+            "~/ceai_ws/src/aegis_ros/aegis_utils/config/tool_front_left_extrinsics.yaml"
+        ).expanduser(),
+    }
+
+    files_missing = {
+        name: not path.is_file() for name, path in calibration_extrinsics_paths.items()
+    }
+
+    if any(files_missing.values()):
+        logger.warn(
+            "Following calibration files are missing:\n"
+            + "\n".join(
+                str(calibration_extrinsics_paths[name])
+                for name, missing in files_missing.items()
+                if missing
+            )
+        )
+        logger.warn(
+            "[WARN] Static TF will not be published for cameras:\n"
+            + "\n".join(name for name, missing in files_missing.items() if missing)
+        )
+        time.sleep(6)
 
     camera_scene_node = create_camera_node(
         cfg.mock_hardware,
@@ -175,15 +201,20 @@ def launch_setup(context: LaunchContext) -> list[Node]:
     )
     point_cloud_node = create_point_cloud_node(cfg.mock_hardware, cam_scene_name)
     static_tf_scene_node = create_static_tf_node(
-        cam_scene_extrinsics_path, "ur_base", "cam_scene_rgb"
+        files_missing,
+        calibration_extrinsics_paths,
+        "ur_base",
+        "cam_scene_rgb",
     )
     static_tf_tool_front_right_node = create_static_tf_node(
-        cam_tool_front_right_extrinsics_path,
+        files_missing,
+        calibration_extrinsics_paths,
         "robotiq_hande_end",
         "cam_tool_front_right",
     )
     static_tf_tool_front_left_node = create_static_tf_node(
-        cam_tool_front_left_extrinsics_path,
+        files_missing,
+        calibration_extrinsics_paths,
         "robotiq_hande_end",
         "cam_tool_front_left",
     )
@@ -305,13 +336,14 @@ def create_point_cloud_node(
 
 
 def create_static_tf_node(
-    extrinsics_path: Path, parent_frame: str, child_frame: str
+    files_missing: Dict[str, bool],
+    calibration_extrinsics_paths: Dict[str, Path],
+    parent_frame: str,
+    child_frame: str,
 ) -> Node:
-    file_missing = not extrinsics_path.is_file()
-    if not file_missing:
-        with open(extrinsics_path, "r") as f:
+    if not files_missing[child_frame]:
+        with open(calibration_extrinsics_paths[child_frame], "r") as f:
             data = yaml.safe_load(f)
-
         T = np.array(data["T_base2cam" if "scene" in child_frame else "T_tcp2cam"])
         x, y, z = T[:3, 3]
         qx, qy, qz, qw = Rotation.from_matrix(T[:3, :3]).as_quat()
@@ -319,7 +351,9 @@ def create_static_tf_node(
         x, y, z, qx, qy, qz, qw = 0, 0, 0, 0, 0, 0, 1
 
     return Node(
-        condition=UnlessCondition(TextSubstitution(text=str(file_missing).lower())),
+        condition=UnlessCondition(
+            TextSubstitution(text=str(files_missing[child_frame]).lower())
+        ),
         package="tf2_ros",
         executable="static_transform_publisher",
         name=f"static_tf_{child_frame}",

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -1,14 +1,17 @@
 import json
-import yaml
 import tempfile
 from pathlib import Path
-from launch import LaunchDescription, LaunchContext
+
+import numpy as np
+import yaml
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchContext, LaunchDescription
 from launch.actions import OpaqueFunction
 from launch.conditions import UnlessCondition
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, TextSubstitution
 from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes, Node
 from launch_ros.descriptions import ComposableNode
-from ament_index_python.packages import get_package_share_directory
+from scipy.spatial.transform import Rotation
 
 
 class DepthAIConfig:
@@ -136,6 +139,16 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         }
     }
 
+    cam_scene_extrinsics_path = Path(
+        "~/ceai_ws/src/aegis_ros/aegis_utils/config/scene_extrinsics.yaml"
+    ).expanduser()
+    cam_tool_front_right_extrinsics_path = Path(
+        "~/ceai_ws/src/aegis_ros/aegis_utils/config/tool_front_right_extrinsics.yaml"
+    ).expanduser()
+    cam_tool_front_left_extrinsics_path = Path(
+        "~/ceai_ws/src/aegis_ros/aegis_utils/config/tool_front_left_extrinsics.yaml"
+    ).expanduser()
+
     camera_scene_node = create_camera_node(
         cfg.mock_hardware,
         cam_scene_name,
@@ -161,6 +174,19 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         cfg.mock_hardware, cam_scene_name, cfg.cam_params_path
     )
     point_cloud_node = create_point_cloud_node(cfg.mock_hardware, cam_scene_name)
+    static_tf_scene_node = create_static_tf_node(
+        cam_scene_extrinsics_path, "ur_base", "cam_scene_rgb"
+    )
+    static_tf_tool_front_right_node = create_static_tf_node(
+        cam_tool_front_right_extrinsics_path,
+        "robotiq_hande_end",
+        "cam_tool_front_right",
+    )
+    static_tf_tool_front_left_node = create_static_tf_node(
+        cam_tool_front_left_extrinsics_path,
+        "robotiq_hande_end",
+        "cam_tool_front_left",
+    )
 
     return [
         camera_scene_node,
@@ -170,6 +196,9 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         rectify_tool_left_node,
         spatial_bb_node,
         point_cloud_node,
+        static_tf_scene_node,
+        static_tf_tool_front_right_node,
+        static_tf_tool_front_left_node,
     ]
 
 
@@ -271,5 +300,38 @@ def create_point_cloud_node(
                     ("/points", name + "/pointcloud"),
                 ],
             ),
+        ],
+    )
+
+
+def create_static_tf_node(
+    extrinsics_path: Path, parent_frame: str, child_frame: str
+) -> Node:
+    file_missing = not extrinsics_path.is_file()
+    if not file_missing:
+        with open(extrinsics_path, "r") as f:
+            data = yaml.safe_load(f)
+
+        T = np.array(data["T_base2cam" if "scene" in child_frame else "T_tcp2cam"])
+        x, y, z = T[:3, 3]
+        qx, qy, qz, qw = Rotation.from_matrix(T[:3, :3]).as_quat()
+    else:
+        x, y, z, qx, qy, qz, qw = 0, 0, 0, 0, 0, 0, 1
+
+    return Node(
+        condition=UnlessCondition(TextSubstitution(text=str(file_missing).lower())),
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name=f"static_tf_{child_frame}",
+        arguments=[
+            str(x),
+            str(y),
+            str(z),
+            str(qx),
+            str(qy),
+            str(qz),
+            str(qw),
+            parent_frame,
+            f"{child_frame}_camera_optical_frame_cal",
         ],
     )

--- a/aegis_control/launch/pylon_cameras_driver.launch.py
+++ b/aegis_control/launch/pylon_cameras_driver.launch.py
@@ -1,18 +1,17 @@
-#!/usr/bin/env python3
-
 import os
+from pathlib import Path
 
+import numpy as np
+import yaml
 from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import OpaqueFunction
-from launch.launch_context import LaunchContext
-from launch.substitutions import LaunchConfiguration
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.conditions import UnlessCondition
-from launch_ros.actions import LoadComposableNodes, Node
+from launch.launch_context import LaunchContext
+from launch.substitutions import LaunchConfiguration, TextSubstitution
+from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes, Node
 from launch_ros.descriptions import ComposableNode
-from launch_ros.actions import ComposableNodeContainer
+from scipy.spatial.transform import Rotation
 
 
 def generate_launch_description():
@@ -147,6 +146,13 @@ def launch_node(context: LaunchContext):
     # see https://navigation.ros.org/tutorials/docs/get_backtrace.html
     launch_prefix = ["xterm -e gdb -ex run --args"] if debug else ""
 
+    cam_tool_right_extrinsics_path = Path(
+        "~/ceai_ws/src/aegis_ros/aegis_utils/config/tool_right_extrinsics.yaml"
+    ).expanduser()
+    cam_tool_left_extrinsics_path = Path(
+        "~/ceai_ws/src/aegis_ros/aegis_utils/config/tool_left_extrinsics.yaml"
+    ).expanduser()
+
     node_camera_left = Node(
         package="pylon_ros2_camera_wrapper",
         namespace="",
@@ -192,11 +198,23 @@ def launch_node(context: LaunchContext):
     )
 
     rectify_tool_node = create_rectify_node()
+    static_tf_tool_right_node = create_static_tf_node(
+        cam_tool_right_extrinsics_path,
+        "robotiq_hande_end",
+        "cam_tool_right",
+    )
+    static_tf_tool_left_node = create_static_tf_node(
+        cam_tool_left_extrinsics_path,
+        "robotiq_hande_end",
+        "cam_tool_left",
+    )
 
     return [
         node_camera_left,
         node_camera_right,
         rectify_tool_node,
+        static_tf_tool_right_node,
+        static_tf_tool_left_node,
     ]
 
 
@@ -223,4 +241,37 @@ def create_rectify_node() -> LoadComposableNodes:
         ],
         arguments=["--ros-args", "--log-level", "info"],
         output="both",
+    )
+
+
+def create_static_tf_node(
+    extrinsics_path: Path, parent_frame: str, child_frame: str
+) -> Node:
+    file_missing = not extrinsics_path.is_file()
+    if not file_missing:
+        with open(extrinsics_path, "r") as f:
+            data = yaml.safe_load(f)
+
+        T = np.array(data["T_base2cam" if "scene" in child_frame else "T_tcp2cam"])
+        x, y, z = T[:3, 3]
+        qx, qy, qz, qw = Rotation.from_matrix(T[:3, :3]).as_quat()
+    else:
+        x, y, z, qx, qy, qz, qw = 0, 0, 0, 0, 0, 0, 1
+
+    return Node(
+        condition=UnlessCondition(TextSubstitution(text=str(file_missing).lower())),
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name=f"static_tf_{child_frame}",
+        arguments=[
+            str(x),
+            str(y),
+            str(z),
+            str(qx),
+            str(qy),
+            str(qz),
+            str(qw),
+            parent_frame,
+            f"{child_frame}_camera_optical_frame_cal",
+        ],
     )

--- a/aegis_control/launch/pylon_cameras_driver.launch.py
+++ b/aegis_control/launch/pylon_cameras_driver.launch.py
@@ -1,5 +1,7 @@
 import os
+import time
 from pathlib import Path
+from typing import Dict
 
 import numpy as np
 import yaml
@@ -11,6 +13,7 @@ from launch.launch_context import LaunchContext
 from launch.substitutions import LaunchConfiguration, TextSubstitution
 from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes, Node
 from launch_ros.descriptions import ComposableNode
+from rclpy.logging import get_logger
 from scipy.spatial.transform import Rotation
 
 
@@ -146,12 +149,35 @@ def launch_node(context: LaunchContext):
     # see https://navigation.ros.org/tutorials/docs/get_backtrace.html
     launch_prefix = ["xterm -e gdb -ex run --args"] if debug else ""
 
-    cam_tool_right_extrinsics_path = Path(
-        "~/ceai_ws/src/aegis_ros/aegis_utils/config/tool_right_extrinsics.yaml"
-    ).expanduser()
-    cam_tool_left_extrinsics_path = Path(
-        "~/ceai_ws/src/aegis_ros/aegis_utils/config/tool_left_extrinsics.yaml"
-    ).expanduser()
+    logger = get_logger("pylon_cameras_driver")
+
+    calibration_extrinsics_paths = {
+        "cam_tool_right": Path(
+            "~/ceai_ws/src/aegis_ros/aegis_utils/config/tool_right_extrinsics.yaml"
+        ).expanduser(),
+        "cam_tool_left": Path(
+            "~/ceai_ws/src/aegis_ros/aegis_utils/config/tool_left_extrinsics.yaml"
+        ).expanduser(),
+    }
+
+    files_missing = {
+        name: not path.is_file() for name, path in calibration_extrinsics_paths.items()
+    }
+
+    if any(files_missing.values()):
+        logger.warn(
+            "Following calibration files are missing:\n"
+            + "\n".join(
+                str(calibration_extrinsics_paths[name])
+                for name, missing in files_missing.items()
+                if missing
+            )
+        )
+        logger.warn(
+            "[WARN] Static TF will not be published for cameras:\n"
+            + "\n".join(name for name, missing in files_missing.items() if missing)
+        )
+        time.sleep(6)
 
     node_camera_left = Node(
         package="pylon_ros2_camera_wrapper",
@@ -199,12 +225,14 @@ def launch_node(context: LaunchContext):
 
     rectify_tool_node = create_rectify_node()
     static_tf_tool_right_node = create_static_tf_node(
-        cam_tool_right_extrinsics_path,
+        files_missing,
+        calibration_extrinsics_paths,
         "robotiq_hande_end",
         "cam_tool_right",
     )
     static_tf_tool_left_node = create_static_tf_node(
-        cam_tool_left_extrinsics_path,
+        files_missing,
+        calibration_extrinsics_paths,
         "robotiq_hande_end",
         "cam_tool_left",
     )
@@ -245,13 +273,14 @@ def create_rectify_node() -> LoadComposableNodes:
 
 
 def create_static_tf_node(
-    extrinsics_path: Path, parent_frame: str, child_frame: str
+    files_missing: Dict[str, bool],
+    calibration_extrinsics_paths: Dict[str, Path],
+    parent_frame: str,
+    child_frame: str,
 ) -> Node:
-    file_missing = not extrinsics_path.is_file()
-    if not file_missing:
-        with open(extrinsics_path, "r") as f:
+    if not files_missing[child_frame]:
+        with open(calibration_extrinsics_paths[child_frame], "r") as f:
             data = yaml.safe_load(f)
-
         T = np.array(data["T_base2cam" if "scene" in child_frame else "T_tcp2cam"])
         x, y, z = T[:3, 3]
         qx, qy, qz, qw = Rotation.from_matrix(T[:3, :3]).as_quat()
@@ -259,7 +288,9 @@ def create_static_tf_node(
         x, y, z, qx, qy, qz, qw = 0, 0, 0, 0, 0, 0, 1
 
     return Node(
-        condition=UnlessCondition(TextSubstitution(text=str(file_missing).lower())),
+        condition=UnlessCondition(
+            TextSubstitution(text=str(files_missing[child_frame]).lower())
+        ),
         package="tf2_ros",
         executable="static_transform_publisher",
         name=f"static_tf_{child_frame}",

--- a/aegis_utils/CHANGELOG.md
+++ b/aegis_utils/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [PR-65](https://github.com/AGH-CEAI/aegis_ros/pull/65) - Added static transformation node for cameras from calibration.
 * [PR-61](https://github.com/AGH-CEAI/aegis_ros/pull/61) - Added intrinsic and extrinsic calibration results.
 * [PR-57](https://github.com/AGH-CEAI/aegis_ros/pull/57) - Added calibration positions for data collection.
 

--- a/aegis_utils/CHANGELOG.md
+++ b/aegis_utils/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* [PR-65](https://github.com/AGH-CEAI/aegis_ros/pull/65) - Added static transformation node for cameras from calibration.
 * [PR-61](https://github.com/AGH-CEAI/aegis_ros/pull/61) - Added intrinsic and extrinsic calibration results.
 * [PR-57](https://github.com/AGH-CEAI/aegis_ros/pull/57) - Added calibration positions for data collection.
 
 ### Changed
+
+* [PR-64](https://github.com/AGH-CEAI/aegis_ros/pull/64) - Switched calibration configuration from JSON to YAML and updated formatting style.
+
 ### Deprecated
 ### Removed
 ### Fixed


### PR DESCRIPTION
## Description
This PR adds static TF publishers for cameras based on extrinsic calibration files.
Each camera’s static transform is loaded from its calibration YAML and published automatically.
If a calibration file is missing, the corresponding TF node is skipped.


## Motivation and context
Previously, camera extrinsic calibrations were stored but not used in the launch system.
By publishing static TFs, calibrated camera frames become directly available in the TF tree, which allows for consistent visualization and processing in RViz and downstream nodes.
Knowing the precise camera poses is essential for vision-based robotic manipulation tasks, such as object detection, pose estimation, and hand–eye coordination. With accurate TFs, the robot can interpret visual information in its own coordinate system, enabling tasks like peg-in-hole assembly.


## How has this been tested?
In RViz.


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.