### PR TITLE
Change cameras collision

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         args: [-w]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.2
+    rev: v0.14.0
     hooks:
     -   id: ruff
         args:

--- a/aegis_description/CHANGELOG.md
+++ b/aegis_description/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* [PR-70](https://github.com/AGH-CEAI/aegis_ros/pull/70) - Simplified Basler ace tool collision — replaced individual camera and lens collisions with a single mount collision. Renamed several links and joints, removed unnecessary ones.
+* [PR-72](https://github.com/AGH-CEAI/aegis_ros/pull/72) - Simplified Basler ace tool collision — replaced individual camera and lens collisions with a single mount collision. Renamed several links and joints, removed unnecessary ones.
 * [PR-69](https://github.com/AGH-CEAI/aegis_ros/pull/69) - Changed cell collision.
 * [PR-62](https://github.com/AGH-CEAI/aegis_ros/pull/62) - Changed cell collision.
 * [PR-53](https://github.com/AGH-CEAI/aegis_ros/pull/53) - Renamed `cam_tool` to `cam_tool_front`.

--- a/aegis_description/CHANGELOG.md
+++ b/aegis_description/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* [PR-70](https://github.com/AGH-CEAI/aegis_ros/pull/70) - Simplified Basler ace tool collision — replaced individual camera and lens collisions with a single mount collision. Renamed several links and joints, removed unnecessary ones.
 * [PR-69](https://github.com/AGH-CEAI/aegis_ros/pull/69) - Changed cell collision.
 * [PR-62](https://github.com/AGH-CEAI/aegis_ros/pull/62) - Changed cell collision.
 * [PR-53](https://github.com/AGH-CEAI/aegis_ros/pull/53) - Renamed `cam_tool` to `cam_tool_front`.

--- a/aegis_description/urdf/aegis.xacro
+++ b/aegis_description/urdf/aegis.xacro
@@ -27,7 +27,7 @@
     <xacro:camera_tool_luxonis parent="mount_front_end" prefix="${prefix}"/>
     <xacro:camera_tool_basler parent="mount_right_end" prefix="${prefix}" side="right"/>
     <xacro:camera_tool_basler parent="mount_left_end" prefix="${prefix}" side="left"/>
-    <xacro:lens_computar parent="cam_tool_right_basler" prefix="${prefix}" side="right"/>
-    <xacro:lens_computar parent="cam_tool_left_basler" prefix="${prefix}" side="left"/>
+    <xacro:lens_computar parent="cam_tool_right" prefix="${prefix}" side="right"/>
+    <xacro:lens_computar parent="cam_tool_left" prefix="${prefix}" side="left"/>
   </xacro:macro>
 </robot>

--- a/aegis_description/urdf/aegis.xacro
+++ b/aegis_description/urdf/aegis.xacro
@@ -20,14 +20,14 @@
     <xacro:ft_sensor_schunk_axia80 parent="adapter_to_sensor_end" prefix="${prefix}" mock_hardware="${mock_hardware}"/>
     <xacro:adapter_from_sensor parent="tool_mount_link" prefix="${prefix}"/>
     <xacro:hande_gripper parent="adapter_from_sensor_end" prefix="${prefix}" mock_hardware="${mock_hardware}"/>
-    <xacro:mount_camera_tool_luxonis parent="mount" prefix="${prefix}"/>
-    <xacro:mount_camera_tool_balser parent="adapter_to_mount_camera_tool_right" prefix="${prefix}" side="right"/>
-    <xacro:mount_camera_tool_balser parent="adapter_to_mount_camera_tool_left" prefix="${prefix}" side="left"/>
+    <xacro:mount_camera_tool_luxonis parent="adapter_mount_front" prefix="${prefix}"/>
+    <xacro:mount_camera_tool_basler parent="adapter_mount_right" prefix="${prefix}" side="right"/>
+    <xacro:mount_camera_tool_basler parent="adapter_mount_left" prefix="${prefix}" side="left"/>
     <xacro:camera_scene_luxonis parent="cell"/>
-    <xacro:camera_tool_luxonis parent="camera_tool" prefix="${prefix}"/>
-    <xacro:camera_tool_basler parent="mount_to_camera_right" prefix="${prefix}" side="right"/>
-    <xacro:camera_tool_basler parent="mount_to_camera_left" prefix="${prefix}" side="left"/>
-    <xacro:lens_computar parent="camera_to_lens_right" prefix="${prefix}" side="right"/>
-    <xacro:lens_computar parent="camera_to_lens_left" prefix="${prefix}" side="left"/>
+    <xacro:camera_tool_luxonis parent="mount_front_end" prefix="${prefix}"/>
+    <xacro:camera_tool_basler parent="mount_right_end" prefix="${prefix}" side="right"/>
+    <xacro:camera_tool_basler parent="mount_left_end" prefix="${prefix}" side="left"/>
+    <xacro:lens_computar parent="cam_tool_right_basler" prefix="${prefix}" side="right"/>
+    <xacro:lens_computar parent="cam_tool_left_basler" prefix="${prefix}" side="left"/>
   </xacro:macro>
 </robot>

--- a/aegis_description/urdf/modules/adapter_to_sensor.xacro
+++ b/aegis_description/urdf/modules/adapter_to_sensor.xacro
@@ -48,28 +48,28 @@
 
     <link name="${prefix}adapter_to_sensor_end"/>
 
-    <joint name="${prefix}adapter_to_mount_camera_tool_right_joint" type="fixed">
+    <joint name="${prefix}adapter_to_mount_right_joint" type="fixed">
       <origin xyz="0 0 ${height_to_adapter}" rpy="0 ${pi} 0"/>
       <parent link="${prefix}adapter_to_sensor"/>
-      <child link="${prefix}adapter_to_mount_camera_tool_right"/>
+      <child link="${prefix}adapter_mount_right"/>
     </joint>
 
-    <link name="${prefix}adapter_to_mount_camera_tool_right"/>
+    <link name="${prefix}adapter_mount_right"/>
 
-    <joint name="${prefix}adapter_to_mount_camera_tool_left_joint" type="fixed">
+    <joint name="${prefix}adapter_to_mount_left_joint" type="fixed">
       <origin xyz="0 0 ${height_to_adapter}" rpy="0 ${pi} ${pi}"/>
       <parent link="${prefix}adapter_to_sensor"/>
-      <child link="${prefix}adapter_to_mount_camera_tool_left"/>
+      <child link="${prefix}adapter_mount_left"/>
     </joint>
 
-    <link name="${prefix}adapter_to_mount_camera_tool_left"/>
+    <link name="${prefix}adapter_mount_left"/>
 
-    <joint name="adapter_to_mount_joint" type="fixed">
+    <joint name="${prefix}adapter_to_mount_front_joint" type="fixed">
       <origin xyz="0 0 ${height_to_adapter}" rpy="0 ${pi} ${pi / 2}"/>
       <parent link="${prefix}adapter_to_sensor"/>
-      <child link="${prefix}mount"/>
+      <child link="${prefix}adapter_mount_front"/>
     </joint>
 
-    <link name="${prefix}mount"/>
+    <link name="${prefix}adapter_mount_front"/>
   </xacro:macro>
 </robot>

--- a/aegis_description/urdf/modules/camera_tool_basler.xacro
+++ b/aegis_description/urdf/modules/camera_tool_basler.xacro
@@ -7,13 +7,13 @@
     <xacro:property name="camera_length" value="0.0603"/>
     <xacro:property name="lens_offset" value="-0.0145"/>
 
-    <joint name="basler_camera_joint_${side}" type="fixed">
+    <joint name="${prefix}camera_${side}_joint" type="fixed">
       <origin xyz="0 ${0.5 * camera_height} ${camera_mounting_offset}" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="${prefix}basler_camera_${side}"/>
+      <child link="${prefix}cam_tool_${side}_basler"/>
     </joint>
 
-    <link name="${prefix}basler_camera_${side}">
+    <link name="${prefix}cam_tool_${side}_basler">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -25,20 +25,6 @@
         <mass value="${camera_mass}"/>
         <inertia ixx="0.3403" ixy="0.0" ixz="0.0" iyy="0.3403" iyz="0.0" izz="0.039606138"/>
       </inertial>
-      <collision>
-        <origin xyz="0 0 ${0.5 * camera_length}" rpy="0 0 0"/>
-        <geometry>
-          <box size="${camera_height} ${camera_height} ${camera_length}"/>
-        </geometry>
-      </collision>
     </link>
-
-    <joint name="${prefix}camera_to_lens_${side}_joint" type="fixed">
-      <origin xyz="0 0 ${lens_offset}" rpy="0 0 0"/>
-      <parent link="${prefix}basler_camera_${side}"/>
-      <child link="${prefix}camera_to_lens_${side}"/>
-    </joint>
-
-    <link name="${prefix}camera_to_lens_${side}"/>
   </xacro:macro>
 </robot>

--- a/aegis_description/urdf/modules/camera_tool_basler.xacro
+++ b/aegis_description/urdf/modules/camera_tool_basler.xacro
@@ -10,10 +10,10 @@
     <joint name="${prefix}camera_${side}_joint" type="fixed">
       <origin xyz="0 ${0.5 * camera_height} ${camera_mounting_offset}" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="${prefix}cam_tool_${side}_basler"/>
+      <child link="${prefix}cam_tool_${side}"/>
     </joint>
 
-    <link name="${prefix}cam_tool_${side}_basler">
+    <link name="${prefix}cam_tool_${side}">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>

--- a/aegis_description/urdf/modules/lens_computar.xacro
+++ b/aegis_description/urdf/modules/lens_computar.xacro
@@ -9,10 +9,10 @@
     <joint name="lens_${side}_joint" type="fixed">
       <origin xyz="0 0 ${lens_offset}" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="${prefix}lens_${side}_computar"/>
+      <child link="${prefix}lens_${side}"/>
     </joint>
 
-    <link name="${prefix}lens_${side}_computar">
+    <link name="${prefix}lens_${side}">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 ${pi}"/>
         <geometry>

--- a/aegis_description/urdf/modules/lens_computar.xacro
+++ b/aegis_description/urdf/modules/lens_computar.xacro
@@ -4,14 +4,15 @@
     <xacro:property name="lens_mass" value="0.063"/>
     <xacro:property name="lens_radius" value="0.01660"/>
     <xacro:property name="lens_height" value="0.02890"/>
+    <xacro:property name="lens_offset" value="-0.0145"/>
 
-    <joint name="lens_computar_joint_${side}" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0"/>
+    <joint name="lens_${side}_joint" type="fixed">
+      <origin xyz="0 0 ${lens_offset}" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="${prefix}lens_computar_${side}"/>
+      <child link="${prefix}lens_${side}_computar"/>
     </joint>
 
-    <link name="${prefix}lens_computar_${side}">
+    <link name="${prefix}lens_${side}_computar">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 ${pi}"/>
         <geometry>
@@ -33,12 +34,6 @@
           izz="${(lens_mass/12.0) * (3*lens_radius*lens_radius + lens_height*lens_height)}"
         />
       </inertial>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 ${pi}"/>
-        <geometry>
-          <cylinder radius="${lens_radius}" length="${lens_height}"/>
-        </geometry>
-      </collision>
     </link>
   </xacro:macro>
 </robot>

--- a/aegis_description/urdf/modules/mount_camera_tool_basler.xacro
+++ b/aegis_description/urdf/modules/mount_camera_tool_basler.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="mount_camera_tool_balser" params="prefix parent side">
+  <xacro:macro name="mount_camera_tool_basler" params="prefix parent side">
     <xacro:property name="mass" value="0.217"/>
     <xacro:property name="mounting_width" value="0.07000"/>
     <xacro:property name="mounting_height" value="0.01360"/>
@@ -10,13 +10,13 @@
     <xacro:property name="mounting_dist_z" value="-0.06607"/>
     <xacro:property name="mounting_dist_x" value="0.119084"/>
 
-    <joint name="mount_camera_tool_balser_joint_${side}" type="fixed">
+    <joint name="${prefix}mount_${side}_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="${prefix}mount_camera_tool_balser_${side}"/>
+      <child link="${prefix}mount_${side}"/>
     </joint>
 
-    <link name="${prefix}mount_camera_tool_balser_${side}">
+    <link name="${prefix}mount_${side}">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -29,19 +29,43 @@
         <inertia ixx="116e-6" ixy="0" ixz="37.5e-6" iyy="196e-6" iyz="0" izz="106e-6"/>
       </inertial>
       <collision>
-        <origin xyz="${1.0 * mounting_size_x} 0 ${-1.0 * mounting_height}" rpy="0 0 0"/>
+        <origin xyz="0.048 0 0" rpy="0 0 0"/>
         <geometry>
-          <box size="${mounting_size_x} ${mounting_width} ${3.0 * mounting_height}"/>
+          <box size="0.01 0.086 0.06"/>
         </geometry>
       </collision>
+      <collision>
+        <origin xyz="0.11 0 -0.026" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.114 0.04 0.088"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0.105 0 -0.08" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.104 0.04 0.02"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0.096 0 -0.1" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.086 0.04 0.02"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin xyz="0.091 0 -0.125" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.076 0.04 0.03"/>
+        </geometry>
+      </collision> 
     </link>
 
-    <joint name="${prefix}mount_camera_tool_balser_${side}_joint" type="fixed">
+    <joint name="${prefix}mount_${side}_end_joint" type="fixed">
       <origin xyz="${mounting_dist_x} 0 ${mounting_dist_z}" rpy="${mounting_yaw} 0 ${-0.5 * pi}"/>
-      <parent link="${prefix}mount_camera_tool_balser_${side}"/>
-      <child link="${prefix}mount_to_camera_${side}"/>
+      <parent link="${prefix}mount_${side}"/>
+      <child link="${prefix}mount_${side}_end"/>
     </joint>
 
-    <link name="${prefix}mount_to_camera_${side}"/>
+    <link name="${prefix}mount_${side}_end"/>
   </xacro:macro>
 </robot>

--- a/aegis_description/urdf/modules/mount_camera_tool_basler.xacro
+++ b/aegis_description/urdf/modules/mount_camera_tool_basler.xacro
@@ -57,7 +57,7 @@
         <geometry>
           <box size="0.076 0.04 0.03"/>
         </geometry>
-      </collision> 
+      </collision>
     </link>
 
     <joint name="${prefix}mount_${side}_end_joint" type="fixed">

--- a/aegis_description/urdf/modules/mount_camera_tool_luxonis.xacro
+++ b/aegis_description/urdf/modules/mount_camera_tool_luxonis.xacro
@@ -2,16 +2,14 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="mount_camera_tool_luxonis" params="prefix parent">
     <xacro:property name="mass" value="0.4"/>
-    <xacro:property name="mounting_dist_x" value="0.091"/>
-    <xacro:property name="mounting_dist_z" value="-0.014"/>
 
-    <joint name="${prefix}mount_camera_joint" type="fixed">
+    <joint name="${prefix}mount_front_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <parent link="${parent}"/>
-      <child link="${prefix}mount_camera"/>
+      <child link="${prefix}mount_front"/>
     </joint>
 
-    <link name="${prefix}mount_camera">
+    <link name="${prefix}mount_front">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
@@ -24,19 +22,19 @@
         <inertia ixx="27.3e-6" ixy="0" ixz="4.19e-6" iyy="19.7e-6" iyz="0" izz="43.38e-6"/>
       </inertial>
       <collision>
-        <origin xyz="0.084 0 -0.01" rpy="0 0 0"/>
+        <origin xyz="0.084 0 0" rpy="0 0 0"/>
         <geometry>
-          <box size="0.076 0.1 0.12"/>
+          <box size="0.08 0.1 0.142"/>
         </geometry>
       </collision>
     </link>
 
-    <joint name="${prefix}mount_to_camera_joint" type="fixed">
+    <joint name="${prefix}mount_front_end_joint" type="fixed">
       <origin xyz="0.091 0 -0.012" rpy="0 0 ${-pi}"/>
-      <parent link="${prefix}mount_camera"/>
-      <child link="${prefix}camera_tool"/>
+      <parent link="${prefix}mount_front"/>
+      <child link="${prefix}mount_front_end"/>
     </joint>
 
-    <link name="${prefix}camera_tool"/>
+    <link name="${prefix}mount_front_end"/>
   </xacro:macro>
 </robot>

--- a/aegis_utils/config/cam_tool_front.yaml
+++ b/aegis_utils/config/cam_tool_front.yaml
@@ -15,10 +15,10 @@ positions:
     wrist_3_joint: 0.5313
   -
     shoulder_pan_joint: 0.4006
-    shoulder_lift_joint: -1.4642
+    shoulder_lift_joint: -1.5304
     elbow_joint: 1.5825
     wrist_1_joint: -1.4043
-    wrist_2_joint: -2.0506
+    wrist_2_joint: -1.9186
     wrist_3_joint: 0.7487
   -
     shoulder_pan_joint: 0.2969


### PR DESCRIPTION
## Description
This PR updates the robot description so that the mount collision now covers the mount itself, the camera, and the lens.
It also renames several links and joints and removes unnecessary ones.


## Motivation and context
This improves safety by reducing the risk of collisions with cameras, and simplifies the collision model since only the mount needs to be considered rather than separate mount, camera and lens collisions.

## Related PRs
- #69
- #71

## Screenshots
<img width="1249" height="1237" alt="screen" src="https://github.com/user-attachments/assets/367ede47-ba1c-4444-a951-742efb965760" />


## How has this been tested?
In RViz.

## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
ClickUp Task: [869aen2ec](https://app.clickup.com/t/869aen2ec)