### PR TITLE
`aegis_director`: Enable MoveIt2 Servo joints & tcp control 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.8.0
+    rev: v0.9.0
     hooks:
     -   id: pre-commit-update
 
@@ -35,7 +35,7 @@ repos:
         args: [-w]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
+    rev: v0.14.3
     hooks:
     -   id: ruff
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         args: [-w]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.3
+    rev: v0.14.4
     hooks:
     -   id: ruff
         args:

--- a/aegis/CHANGELOG.md
+++ b/aegis/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* [PR-75](https://github.com/AGH-CEAI/aegis_ros/pull/75) - Changed `pymoveit2` upstream repo to a [custom fork](https://github.com/macmacal/pymoveit2).
 * [PR-68](https://github.com/AGH-CEAI/aegis_ros/pull/68) - Updated repos for new robotiq_hande_driver fix.
 
 ### Deprecated

--- a/aegis/aegis.repos
+++ b/aegis/aegis.repos
@@ -18,7 +18,7 @@ repositories:
   pymoveit2:
     type: git
     url: https://github.com/AndrejOrsula/pymoveit2.git
-    version: 4.1.1
+    version: 4.2.0
   pylon_ros_camera:
     type: git
     url: https://github.com/basler/pylon-ros-camera.git

--- a/aegis/aegis.repos
+++ b/aegis/aegis.repos
@@ -17,8 +17,8 @@ repositories:
     version: 96a370865c7ac15622a74123e93a1b96b26dcee7
   pymoveit2:
     type: git
-    url: https://github.com/AndrejOrsula/pymoveit2.git
-    version: 4.2.0
+    url: https://github.com/macmacal/pymoveit2.git
+    version: ec3e1edc7ec133e40dc2e2cd7d2a8439716f2b6c
   pylon_ros_camera:
     type: git
     url: https://github.com/basler/pylon-ros-camera.git

--- a/aegis_director/CHANGELOG.md
+++ b/aegis_director/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+* [PR-75](https://github.com/AGH-CEAI/aegis_ros/pull/75) - Added methods for controlling MoveIt2 Servo (Twist & Jog).
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/aegis_director/aegis_director/robot_director.py
+++ b/aegis_director/aegis_director/robot_director.py
@@ -4,7 +4,7 @@ from typing import Iterable, Optional, Union
 
 import numpy as np
 import rclpy
-from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.callback_groups import ReentrantCallbackGroup, MutuallyExclusiveCallbackGroup
 from rclpy.node import Node
 from controller_manager_msgs.srv import SwitchController
 from geometry_msgs.msg import Point, Pose, PoseStamped, Quaternion
@@ -19,6 +19,7 @@ class RobotDirector:
         self.synchronous = synchronous
         self.node = Node("director")
         self.cb_group = ReentrantCallbackGroup()
+        self.cb_exclusive_group = MutuallyExclusiveCallbackGroup()
 
         self._prepare_moveit2()
         self._preapre_servo()
@@ -28,8 +29,6 @@ class RobotDirector:
         self.executor.add_node(self.node)
         self.executor_thread = Thread(target=self.executor.spin, daemon=True, args=())
         self.executor_thread.start()
-        # Sleep a while in order to get the first joint state
-        self.node.create_rate(10.0).sleep()
 
         # Ensure that the servo is disabled
         self.servo.disable(sync=True)
@@ -58,7 +57,9 @@ class RobotDirector:
             enable_at_init=False,
         )
         self.switch_controllers = self.node.create_client(
-            SwitchController, "/controller_manager/switch_controller"
+            SwitchController,
+            "/controller_manager/switch_controller",
+            callback_group=self.cb_exclusive_group,
         )
         if not self.switch_controllers.wait_for_service(timeout_sec=5.0):
             self.node.get_logger().warn(
@@ -133,23 +134,33 @@ class RobotDirector:
     def servo_enable(self) -> None:
         if self.servo_enabled:
             return
+        self.servo.enable(sync=False)
         self._switch_controllers(
             activate=["forward_position_controller"],
             deactivate=["scaled_joint_trajectory_controller"],
         )
-        self.servo.enable(sync=False)
-        time.sleep(3.0)  # HACK workaround for sync wait deadlock
+
+        # TODO(issue#X) ROS spin deadlockswith synchronous calls
+        # HACK workaround for sync wait deadlock
+        time.sleep(1.0)
+        self.servo.__is_enabled = True
+
         self._servo_enabled = True
 
     def servo_disable(self) -> None:
         if not self.servo_enabled:
             return
         self.servo.disable(sync=False)
-        time.sleep(3.0)  # HACK workaround for sync wait deadlock
         self._switch_controllers(
             activate=["scaled_joint_trajectory_controller"],
             deactivate=["forward_position_controller"],
         )
+
+        # TODO(issue#X) ROS spin deadlockswith synchronous calls
+        # HACK workaround for sync wait deadlock
+        time.sleep(1.0)
+        self.servo.__is_enabled = False
+
         self._servo_enabled = False
 
     def _switch_controllers(
@@ -164,7 +175,6 @@ class RobotDirector:
             else SwitchController.Request.BEST_EFFORT
         )
         self.switch_controllers.call_async(req)
-        time.sleep(1.0)  # HACK workaround for sync wait deadlock
 
     def joint_move(
         self,

--- a/aegis_director/aegis_director/robot_director.py
+++ b/aegis_director/aegis_director/robot_director.py
@@ -136,7 +136,7 @@ class RobotDirector:
             deactivate=["scaled_joint_trajectory_controller"],
         )
 
-        # TODO(issue#X) ROS spin deadlockswith synchronous calls
+        # TODO(issue#76) ROS spin deadlockswith synchronous calls
         # HACK workaround for sync wait deadlock
         time.sleep(1.0)
         self.servo.__is_enabled = True
@@ -152,7 +152,7 @@ class RobotDirector:
             deactivate=["forward_position_controller"],
         )
 
-        # TODO(issue#X) ROS spin deadlockswith synchronous calls
+        # TODO(issue#76) ROS spin deadlockswith synchronous calls
         # HACK workaround for sync wait deadlock
         time.sleep(1.0)
         self.servo.__is_enabled = False

--- a/aegis_director/aegis_director/robot_director.py
+++ b/aegis_director/aegis_director/robot_director.py
@@ -266,6 +266,18 @@ class RobotDirector:
             return
         self.servo.servo(linear=linear, angular=angular, enable_if_disabled=False)
 
+    def servo_jog(
+        self,
+        joint_names: tuple[str, ...],
+        velocities: tuple[float, ...] = tuple(),
+    ) -> None:
+        if not self.servo_enabled:
+            self.node.get_logger().warn("Enable servo before moving. Ignoring.")
+            return
+        self.servo.servo_jog(
+            joint_names=joint_names, velocities=velocities, enable_if_disabled=False
+        )
+
     def _wait_for_move_execution(self, cancel_after_secs: float = 0.0) -> None:
         if self.synchronous:
             self.moveit2.wait_until_executed()

--- a/aegis_director/aegis_director/robot_director.py
+++ b/aegis_director/aegis_director/robot_director.py
@@ -1,15 +1,16 @@
 import time
 from threading import Thread
-from typing import Optional, Union
+from typing import Iterable, Optional, Union
 
 import numpy as np
 import rclpy
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.node import Node
+from controller_manager_msgs.srv import SwitchController
 from geometry_msgs.msg import Point, Pose, PoseStamped, Quaternion
 from sensor_msgs.msg import JointState
 
-from pymoveit2 import MoveIt2, MoveIt2State, GripperInterface
+from pymoveit2 import MoveIt2, MoveIt2State, GripperInterface, MoveIt2Servo
 import aegis_director.aegis_robot as robot
 
 
@@ -19,6 +20,18 @@ class RobotDirector:
         self.node = Node("director")
         self.cb_group = ReentrantCallbackGroup()
 
+        self._prepare_moveit2()
+        self._preapre_servo()
+        self._preapre_gripper_interface()
+
+        self.executor = rclpy.executors.MultiThreadedExecutor()
+        self.executor.add_node(self.node)
+        self.executor_thread = Thread(target=self.executor.spin, daemon=True, args=())
+        self.executor_thread.start()
+        # Sleep a while in order to get the first joint state
+        self.node.create_rate(10.0).sleep()
+
+    def _prepare_moveit2(self) -> None:
         self.moveit2 = MoveIt2(
             node=self.node,
             joint_names=robot.joint_names(),
@@ -29,6 +42,22 @@ class RobotDirector:
         )
         self.moveit2.planner_id = "RRTConnectkConfigDefault"
 
+    def _preapre_servo(self) -> None:
+        self.servo = MoveIt2Servo(
+            node=self.node,
+            frame_id=robot.base_link_name(),
+            callback_group=self.cb_group,
+            enable_at_init=False,
+        )
+        self.switch_controllers = self.node.create_client(
+            SwitchController, "/controller_manager/switch_controller"
+        )
+        if not self.switch_controllers.wait_for_service(timeout_sec=5.0):
+            self.node.get_logger().warn(
+                f"Service {self.switch_controllers.srv_name} not available"
+            )
+
+    def _preapre_gripper_interface(self) -> None:
         self.gripper_interface = GripperInterface(
             node=self.node,
             gripper_joint_names=robot.gripper_joint_names(),
@@ -38,13 +67,6 @@ class RobotDirector:
             callback_group=self.cb_group,
             gripper_command_action_name="gripper_action_controller/gripper_cmd",
         )
-
-        self.executor = rclpy.executors.MultiThreadedExecutor()
-        self.executor.add_node(self.node)
-        self.executor_thread = Thread(target=self.executor.spin, daemon=True, args=())
-        self.executor_thread.start()
-        # Sleep a while in order to get the first joint state
-        self.node.create_rate(10.0).sleep()
 
     def __del__(self):
         if self.executor_thread.is_alive():
@@ -95,6 +117,37 @@ class RobotDirector:
         if retval is None:
             raise ValueError("Failed to obtain TCP pose (i.e. calculate FK).")
         return retval.pose
+
+    def servo_enable(self) -> None:
+        if self.servo.is_enabled:
+            return
+        assert self._switch_controllers(
+            activate=["scaled_joint_trajectory_controller"],
+            deactivate=["scaled_joint_trajectory_controller"],
+        ), "Failed to switch controllers during enabling the servo."
+        self.servo.enable(sync=True)
+
+    def servo_disable(self) -> None:
+        if not self.servo.is_enabled:
+            return
+        assert self._switch_controllers(
+            activate=["scaled_joint_trajectory_controller"],
+            deactivate=["forward_position_controller"],
+        ), "Failed to switch controllers during disabling the servo."
+        self.servo.disable(sync=True)
+
+    def _switch_controllers(
+        self, activate: Iterable[str], deactivate: Iterable[str], strict=True
+    ) -> bool:
+        req = SwitchController.Request()
+        req.activate_controllers = activate
+        req.deactivate_controllers = deactivate
+        req.strictness = (
+            SwitchController.Request.STRICT
+            if strict
+            else SwitchController.Request.BEST_EFFORT
+        )
+        return self.switch_controllers.call(req).ok
 
     def joint_move(
         self,
@@ -186,10 +239,15 @@ class RobotDirector:
         self.gripper_interface.move_to_position(width)
         self._wait_for_gripper_execution()
 
-    def servo_move(self) -> None:
-        # Placeholder for future implementation
-        # from pymoveit2 import MoveIt2Servo
-        self.node.get_logger().warn("Servo movement is not implemented yet. Ignoring.")
+    def servo_move(
+        self,
+        linear: tuple[float, float, float] = (0.0, 0.0, 0.0),
+        angular: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    ) -> None:
+        if not self.servo.is_enabled:
+            self.node.get_logger().warn("Enable servo before moving. Ignoring.")
+            return
+        self.servo(linear=linear, angular=angular, enable_if_disabled=False)
 
     def _wait_for_move_execution(self, cancel_after_secs: float = 0.0) -> None:
         if self.synchronous:

--- a/aegis_director/aegis_director/robot_director.py
+++ b/aegis_director/aegis_director/robot_director.py
@@ -56,6 +56,11 @@ class RobotDirector:
             self.node.get_logger().warn(
                 f"Service {self.switch_controllers.srv_name} not available"
             )
+        self._servo_enabled = False
+
+    @property
+    def servo_enabled(self) -> bool:
+        return self._servo_enabled
 
     def _preapre_gripper_interface(self) -> None:
         self.gripper_interface = GripperInterface(
@@ -119,22 +124,24 @@ class RobotDirector:
         return retval.pose
 
     def servo_enable(self) -> None:
-        if self.servo.is_enabled:
+        if self.servo_enabled:
             return
         assert self._switch_controllers(
             activate=["scaled_joint_trajectory_controller"],
             deactivate=["scaled_joint_trajectory_controller"],
         ), "Failed to switch controllers during enabling the servo."
         self.servo.enable(sync=True)
+        self._servo_enabled = True
 
     def servo_disable(self) -> None:
-        if not self.servo.is_enabled:
+        if not self.servo_enabled:
             return
         assert self._switch_controllers(
             activate=["scaled_joint_trajectory_controller"],
             deactivate=["forward_position_controller"],
         ), "Failed to switch controllers during disabling the servo."
         self.servo.disable(sync=True)
+        self._servo_enabled = False
 
     def _switch_controllers(
         self, activate: Iterable[str], deactivate: Iterable[str], strict=True
@@ -244,10 +251,10 @@ class RobotDirector:
         linear: tuple[float, float, float] = (0.0, 0.0, 0.0),
         angular: tuple[float, float, float] = (0.0, 0.0, 0.0),
     ) -> None:
-        if not self.servo.is_enabled:
+        if not self.servo_enabled:
             self.node.get_logger().warn("Enable servo before moving. Ignoring.")
             return
-        self.servo(linear=linear, angular=angular, enable_if_disabled=False)
+        self.servo.servo(linear=linear, angular=angular, enable_if_disabled=False)
 
     def _wait_for_move_execution(self, cancel_after_secs: float = 0.0) -> None:
         if self.synchronous:

--- a/aegis_director/aegis_director/robot_director.py
+++ b/aegis_director/aegis_director/robot_director.py
@@ -31,6 +31,14 @@ class RobotDirector:
         # Sleep a while in order to get the first joint state
         self.node.create_rate(10.0).sleep()
 
+        # Ensure that the servo is disabled
+        self.servo.disable(sync=True)
+        self._switch_controllers(
+            activate=["scaled_joint_trajectory_controller"],
+            deactivate=["forward_position_controller"],
+        )
+        self._servo_enabled = False
+
     def _prepare_moveit2(self) -> None:
         self.moveit2 = MoveIt2(
             node=self.node,
@@ -56,7 +64,6 @@ class RobotDirector:
             self.node.get_logger().warn(
                 f"Service {self.switch_controllers.srv_name} not available"
             )
-        self._servo_enabled = False
 
     @property
     def servo_enabled(self) -> bool:
@@ -126,26 +133,28 @@ class RobotDirector:
     def servo_enable(self) -> None:
         if self.servo_enabled:
             return
-        assert self._switch_controllers(
-            activate=["scaled_joint_trajectory_controller"],
+        self._switch_controllers(
+            activate=["forward_position_controller"],
             deactivate=["scaled_joint_trajectory_controller"],
-        ), "Failed to switch controllers during enabling the servo."
-        self.servo.enable(sync=True)
+        )
+        self.servo.enable(sync=False)
+        time.sleep(3.0)  # HACK workaround for sync wait deadlock
         self._servo_enabled = True
 
     def servo_disable(self) -> None:
         if not self.servo_enabled:
             return
-        assert self._switch_controllers(
+        self.servo.disable(sync=False)
+        time.sleep(3.0)  # HACK workaround for sync wait deadlock
+        self._switch_controllers(
             activate=["scaled_joint_trajectory_controller"],
             deactivate=["forward_position_controller"],
-        ), "Failed to switch controllers during disabling the servo."
-        self.servo.disable(sync=True)
+        )
         self._servo_enabled = False
 
     def _switch_controllers(
         self, activate: Iterable[str], deactivate: Iterable[str], strict=True
-    ) -> bool:
+    ) -> None:
         req = SwitchController.Request()
         req.activate_controllers = activate
         req.deactivate_controllers = deactivate
@@ -154,7 +163,8 @@ class RobotDirector:
             if strict
             else SwitchController.Request.BEST_EFFORT
         )
-        return self.switch_controllers.call(req).ok
+        self.switch_controllers.call_async(req)
+        time.sleep(1.0)  # HACK workaround for sync wait deadlock
 
     def joint_move(
         self,
@@ -248,7 +258,7 @@ class RobotDirector:
 
     def servo_move(
         self,
-        linear: tuple[float, float, float] = (0.0, 0.0, 0.0),
+        linear: tuple[float, float, float],
         angular: tuple[float, float, float] = (0.0, 0.0, 0.0),
     ) -> None:
         if not self.servo_enabled:

--- a/aegis_director/aegis_director/robot_director.py
+++ b/aegis_director/aegis_director/robot_director.py
@@ -31,12 +31,8 @@ class RobotDirector:
         self.executor_thread.start()
 
         # Ensure that the servo is disabled
-        self.servo.disable(sync=True)
-        self._switch_controllers(
-            activate=["scaled_joint_trajectory_controller"],
-            deactivate=["forward_position_controller"],
-        )
-        self._servo_enabled = False
+        self._servo_enabled = True
+        self.servo_disable()
 
     def _prepare_moveit2(self) -> None:
         self.moveit2 = MoveIt2(

--- a/aegis_director/aegis_director/robot_director.py
+++ b/aegis_director/aegis_director/robot_director.py
@@ -82,9 +82,9 @@ class RobotDirector:
         )
 
     def __del__(self):
+        self.executor.shutdown()
         if self.executor_thread.is_alive():
             self.executor_thread.join()
-        self.executor.shutdown()
         self.node.destroy_node()
 
     def get_joint_positions(self) -> dict[str, float]:

--- a/aegis_moveit_config/CHANGELOG.md
+++ b/aegis_moveit_config/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* [PR-75](https://github.com/AGH-CEAI/aegis_ros/pull/75) - Updated servo max linear, angular and joints velocities.
 * [PR-71](https://github.com/AGH-CEAI/aegis_ros/pull/71) - Updated collision checking.
 * [PR-68](https://github.com/AGH-CEAI/aegis_ros/pull/68) - Updated RViz config for proper QoS RGB camera config.
 * [PR-60](https://github.com/AGH-CEAI/aegis_ros/pull/60) - Disabled MoveIt's Trajectory Execution Monitoring (TEM) - it is now possible to scale down robot speeds without trajectory errors.

--- a/aegis_moveit_config/config/move_group/ur_servo.yaml
+++ b/aegis_moveit_config/config/move_group/ur_servo.yaml
@@ -8,10 +8,10 @@ use_gazebo: false # Whether the robot is started in a Gazebo simulation environm
 command_in_type: "unitless"
 scale:
   # Scale parameters are only used if command_in_type=="unitless"
-  linear:  0.3  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
-  rotational:  0.15 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
+  linear:  0.5  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
+  rotational:  0.35 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
-  joint: 0.5
+  joint: 0.35 # ~ 20 deg/s
 # This is a fudge factor to account for any latency in the system, e.g. network latency or poor low-level
 # controller performance. It essentially increases the timestep when calculating the target pose, to move the target
 # pose farther away. [seconds]

--- a/aegis_moveit_config/config/move_group/ur_servo.yaml
+++ b/aegis_moveit_config/config/move_group/ur_servo.yaml
@@ -8,8 +8,8 @@ use_gazebo: false # Whether the robot is started in a Gazebo simulation environm
 command_in_type: "unitless"
 scale:
   # Scale parameters are only used if command_in_type=="unitless"
-  linear:  0.5  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
-  rotational:  0.35 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
+  linear: 0.5 # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
+  rotational: 0.35 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
   joint: 0.35 # ~ 20 deg/s
 # This is a fudge factor to account for any latency in the system, e.g. network latency or poor low-level
@@ -18,8 +18,8 @@ scale:
 system_latency_compensation: 0.04
 
 ## Properties of outgoing commands
-publish_period: 0.004  # 1/Nominal publish rate [seconds]
-low_latency_mode: false  # Set this to true to publish as soon as an incoming Twist command is received (publish_period is ignored)
+publish_period: 0.004 # 1/Nominal publish rate [seconds]
+low_latency_mode: false # Set this to true to publish as soon as an incoming Twist command is received (publish_period is ignored)
 
 # What type of topic does your robot driver expect?
 # Currently supported are std_msgs/Float64MultiArray or trajectory_msgs/JointTrajectory
@@ -41,28 +41,28 @@ smoothing_filter_plugin_name: "online_signal_smoothing::ButterworthFilterPlugin"
 is_primary_planning_scene_monitor: false # WARNING: CHANGE TO FALSE BEFORE FURTHER DEV
 
 ## Incoming Joint State properties
-low_pass_filter_coeff: 10.0  # Larger --> trust the filtered data more, trust the measurements less.
+low_pass_filter_coeff: 10.0 # Larger --> trust the filtered data more, trust the measurements less.
 
-move_group_name:  aegis_arm  # Often 'manipulator' or 'arm'
-planning_frame: base_link  # The MoveIt planning frame. Often 'base_link' or 'world'
+move_group_name: aegis_arm # Often 'manipulator' or 'arm'
+planning_frame: base_link # The MoveIt planning frame. Often 'base_link' or 'world'
 
 ## Other frames
-ee_frame_name: robotiq_hande_end  # The name of the end effector link, used to return the EE pose
-robot_link_command_frame:  base_link  # commands must be given in the frame of a robot link. Usually either the base or end effector
+ee_frame_name: robotiq_hande_end # The name of the end effector link, used to return the EE pose
+robot_link_command_frame: base_link # commands must be given in the frame of a robot link. Usually either the base or end effector
 
 ## Stopping behaviour
-incoming_command_timeout:  0.1  # Stop servoing if X seconds elapse without a new command
+incoming_command_timeout: 0.1 # Stop servoing if X seconds elapse without a new command
 # If 0, republish commands forever even if the robot is stationary. Otherwise, specify num. to publish.
 # Important because ROS may drop some messages and we need the robot to halt reliably.
 num_outgoing_halt_msgs_to_publish: 4
 
 ## Configure handling of singularities and joint limits
-lower_singularity_threshold:  150.0  # Start decelerating when the condition number hits this (close to singularity)
+lower_singularity_threshold: 150.0 # Start decelerating when the condition number hits this (close to singularity)
 hard_stop_singularity_threshold: 200.0 # Stop when the condition number hits this
 joint_limit_margin: 0.1 # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
 
 ## Topic names
-cartesian_command_in_topic: ~/delta_twist_cmds  # Topic for incoming Cartesian twist commands
+cartesian_command_in_topic: ~/delta_twist_cmds # Topic for incoming Cartesian twist commands
 joint_command_in_topic: ~/delta_joint_cmds # Topic for incoming joint angle commands
 joint_topic: /joint_states
 status_topic: ~/status # Publish status to this topic


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This PR extends the `aegis_director` functionality to provide methods to call the MoveIt2 Servo control, both in Cartesian space (in our case its just TCP) and in joints space.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Provide control for RL experiments.

## Related PRs
* https://github.com/AGH-CEAI/aegis_gym/pull/32
* https://github.com/AndrejOrsula/pymoveit2/pull/117
* https://github.com/AndrejOrsula/pymoveit2/pull/118


<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually on the Aegis station.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [869arfjkv](https://app.clickup.com/t/869arfjkv)
