### PR TITLE
Enable gRPC-based robot motion commands with MoveIt

### DIFF
--- a/aegis_grpc/CHANGELOG.md
+++ b/aegis_grpc/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* [PR-88](https://github.com/AGH-CEAI/aegis_ros/pull/88) - Added gRPC robot motion commands with MoveIt.
 * [PR-88](https://github.com/AGH-CEAI/aegis_ros/pull/88) - MVP of the gRPC Python client.
 * [PR-82](https://github.com/AGH-CEAI/aegis_ros/pull/82) - MVP of the gRPC-ROS server.
 

--- a/aegis_grpc/CMakeLists.txt
+++ b/aegis_grpc/CMakeLists.txt
@@ -27,8 +27,8 @@ set(ROS_DEPENDS
 # Hide warnings from importing moveit packages
 cmake_policy(SET CMP0167 NEW)
 
-foreach(ROS_DEP ${ROS_DEPENDS})
-  find_package(${ROS_DEP} REQUIRED)
+foreach(ros_dep ${ROS_DEPENDS})
+  find_package(${ros_dep} REQUIRED)
 endforeach()
 
 # gRPC package for Ubuntu 22.04 (ROS Humble) can't be find by CMake's find_package()

--- a/aegis_grpc/CMakeLists.txt
+++ b/aegis_grpc/CMakeLists.txt
@@ -14,20 +14,22 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Dependencies
 
 find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_action REQUIRED)
-find_package(control_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(sensor_msgs REQUIRED)
 
 set(ROS_DEPENDS
     rclcpp
     rclcpp_action
     control_msgs
     geometry_msgs
-    sensor_msgs)
+    sensor_msgs
+    moveit_msgs
+    moveit_ros_planning_interface)
 
-find_program(GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin REQUIRED)
+# Hide warnings from importing moveit packages
+cmake_policy(SET CMP0167 NEW)
+
+foreach(ROS_DEP ${ROS_DEPENDS})
+  find_package(${ROS_DEP} REQUIRED)
+endforeach()
 
 # gRPC package for Ubuntu 22.04 (ROS Humble) can't be find by CMake's find_package()
 # https://bugs.launchpad.net/ubuntu/+source/grpc/+bug/1935709

--- a/aegis_grpc/README.md
+++ b/aegis_grpc/README.md
@@ -104,12 +104,12 @@ The server is split into 2 services defined in [`proto_aegis_grpc.v1.robot_srvs`
 
 The "ROS-getters" are implemented in the [`RobotReadServiceImpl`](./include/aegis_grpc/robot_read_service.hpp) class as the following methods:
 
-| Method name                                          | Desc.                       | Impl. | gRPC Request            | gRPC Response                                                                           |
-| ---------------------------------------------------- | --------------------------- | ----- | ----------------------- | --------------------------------------------------------------------------------------- |
-| `proto_aegis_grpc.v1.RobotReadService.GetAll`        | Get the all available data. | ✅     | `google.protobuf.Empty` | [`proto_aegis_grpc.v1.robot_srvs.RobotState`](./proto_aegis_grpc/v1/robot_srvs.proto)   |
-| `proto_aegis_grpc.v1.RobotReadService.GetJointState` | Get the joints' states.     | ✅     | `google.protobuf.Empty` | [`proto_aegis_grpc.v1.sensor_msgs.JointState`](./proto_aegis_grpc/v1/sensor_msgs.proto) |
-| `proto_aegis_grpc.v1.RobotReadService.GetTCPPose`    | Get the TCP pose.           | ✅     | `google.protobuf.Empty` | [`proto_aegis_grpc.v1.geometry_msgs.Pose`](./proto_aegis_grpc/v1/geometry_msgs.proto)   |
-| `proto_aegis_grpc.v1.RobotReadService.GetWrench`     | Read force/torque sensor.   | ✅     | `google.protobuf.Empty` | [`proto_aegis_grpc.v1.geometry_msgs.Wrench`](./proto_aegis_grpc/v1/geometry_msgs.proto) |
+| Method name                                           | Desc.                       | Impl. | gRPC Request            | gRPC Response                                                                           |
+|-------------------------------------------------------|-----------------------------|-------|-------------------------|-----------------------------------------------------------------------------------------|
+| `proto_aegis_grpc.v1.RobotReadService.GetAll`         | Get the all available data. | ✅     | `google.protobuf.Empty` | [`proto_aegis_grpc.v1.robot_srvs.RobotState`](./proto_aegis_grpc/v1/robot_srvs.proto)   |
+| `proto_aegis_grpc.v1.RobotReadService.GetJointStates` | Get the joints' states.     | ✅     | `google.protobuf.Empty` | [`proto_aegis_grpc.v1.sensor_msgs.JointState`](./proto_aegis_grpc/v1/sensor_msgs.proto) |
+| `proto_aegis_grpc.v1.RobotReadService.GetTCPPose`     | Get the TCP pose.           | ✅     | `google.protobuf.Empty` | [`proto_aegis_grpc.v1.geometry_msgs.Pose`](./proto_aegis_grpc/v1/geometry_msgs.proto)   |
+| `proto_aegis_grpc.v1.RobotReadService.GetWrench`      | Read force/torque sensor.   | ✅     | `google.protobuf.Empty` | [`proto_aegis_grpc.v1.geometry_msgs.Wrench`](./proto_aegis_grpc/v1/geometry_msgs.proto) |
 
 You can always list the methods with the `grpcurl` command:
 ```bash

--- a/aegis_grpc/include/aegis_grpc/robot_control_service.hpp
+++ b/aegis_grpc/include/aegis_grpc/robot_control_service.hpp
@@ -44,7 +44,6 @@ class RobotControlServiceImpl final
         const proto_aegis_grpc::v1::Twist* request,
         google::protobuf::Empty* response) override;
 
-    // TODO(issue#83) add MoveIt2 actions to plan&execute trajectories to targets in Joints and Poses.
     grpc::Status GotoPose(
         grpc::ServerContext* context,
         const proto_aegis_grpc::v1::Pose* request,

--- a/aegis_grpc/include/aegis_grpc/robot_control_service.hpp
+++ b/aegis_grpc/include/aegis_grpc/robot_control_service.hpp
@@ -13,6 +13,8 @@
 #include <control_msgs/msg/joint_jog.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <moveit/move_group_interface/move_group_interface.h>
 
 
 namespace aegis_grpc {
@@ -34,39 +36,39 @@ class RobotControlServiceImpl final
     // TODO(issue#87) Create additional methods to enable and disable servo control.
     grpc::Status ServoJoint(
         grpc::ServerContext* context,
-        const proto_aegis_grpc::v1::JointJog *request,
-        google::protobuf::Empty *response) override;
+        const proto_aegis_grpc::v1::JointJog* request,
+        google::protobuf::Empty* response) override;
 
     grpc::Status ServoTCP(
         grpc::ServerContext* context,
-        const proto_aegis_grpc::v1::Twist *request,
-        google::protobuf::Empty *response) override;
+        const proto_aegis_grpc::v1::Twist* request,
+        google::protobuf::Empty* response) override;
 
     // TODO(issue#83) add MoveIt2 actions to plan&execute trajectories to targets in Joints and Poses.
-    // grpc::Status GotoPose(
-    //     grpc::ServerContext* context,
-    //     const proto_aegis_grpc::v1::Pose *request,
-    //     proto_aegis_grpc::v1::TriggerResponse *response) override;
+    grpc::Status GotoPose(
+        grpc::ServerContext* context,
+        const proto_aegis_grpc::v1::Pose* request,
+        proto_aegis_grpc::v1::TriggerResponse* response) override;
 
-    // grpc::Status GotoJoints(
-    //     grpc::ServerContext* context,
-    //     const proto_aegis_grpc::v1::JointState *request,
-    //     proto_aegis_grpc::v1::TriggerResponse *response) override;
+    grpc::Status GotoJoints(
+        grpc::ServerContext* context,
+        const proto_aegis_grpc::v1::JointState* request,
+        proto_aegis_grpc::v1::TriggerResponse* response) override;
 
     grpc::Status GripperSetPosition(
       grpc::ServerContext* context,
-      const proto_aegis_grpc::v1::GripperSetPositionRequest *request,
-      proto_aegis_grpc::v1::TriggerResponse *response) override;
+      const proto_aegis_grpc::v1::GripperSetPositionRequest* request,
+      proto_aegis_grpc::v1::TriggerResponse* response) override;
 
     grpc::Status GripperClose(
         grpc::ServerContext* context,
-        const google::protobuf::Empty *request,
-        proto_aegis_grpc::v1::TriggerResponse *response) override;
+        const google::protobuf::Empty* request,
+        proto_aegis_grpc::v1::TriggerResponse* response) override;
 
     grpc::Status GripperOpen(
         grpc::ServerContext* context,
-        const google::protobuf::Empty *request,
-        proto_aegis_grpc::v1::TriggerResponse *response) override;
+        const google::protobuf::Empty* request,
+        proto_aegis_grpc::v1::TriggerResponse* response) override;
 
   private:
     rclcpp::Logger get_logger() const;
@@ -78,6 +80,7 @@ class RobotControlServiceImpl final
     void GripperSendGoal(double position, double max_effort);
 
     std::shared_ptr<rclcpp::Node> node_;
+    std::unique_ptr<moveit::planning_interface::MoveGroupInterface> move_group_;
 
     rclcpp::Publisher<control_msgs::msg::JointJog>::SharedPtr servo_joint_pub_;
     rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr servo_tcp_pub_;

--- a/aegis_grpc/include/aegis_grpc/robot_read_service.hpp
+++ b/aegis_grpc/include/aegis_grpc/robot_read_service.hpp
@@ -20,22 +20,22 @@ class RobotReadServiceImpl final
   public:
     explicit RobotReadServiceImpl(std::shared_ptr<rclcpp::Node> node);
 
-    grpc::Status GetTCPPose(grpc::ServerContext *context,
-                            const google::protobuf::Empty *request,
-                            proto_aegis_grpc::v1::Pose *response) override;
+    grpc::Status GetTCPPose(grpc::ServerContext* context,
+                            const google::protobuf::Empty* request,
+                            proto_aegis_grpc::v1::Pose* response) override;
 
-    grpc::Status GetWrench(grpc::ServerContext *context,
-                          const google::protobuf::Empty *request,
-                          proto_aegis_grpc::v1::Wrench *response) override;
+    grpc::Status GetWrench(grpc::ServerContext* context,
+                          const google::protobuf::Empty* request,
+                          proto_aegis_grpc::v1::Wrench* response) override;
 
     grpc::Status
-    GetJointStates(grpc::ServerContext *context,
-                  const google::protobuf::Empty *request,
-                  proto_aegis_grpc::v1::JointState *response) override;
+    GetJointStates(grpc::ServerContext* context,
+                  const google::protobuf::Empty* request,
+                  proto_aegis_grpc::v1::JointState* response) override;
 
-    grpc::Status GetAll(grpc::ServerContext *context,
-                        const google::protobuf::Empty *request,
-                        proto_aegis_grpc::v1::RobotState *response) override;
+    grpc::Status GetAll(grpc::ServerContext* context,
+                        const google::protobuf::Empty* request,
+                        proto_aegis_grpc::v1::RobotState* response) override;
 
     // TODO(issue#84) implement getters for images from cameras (RGB & RGBD)
     // TODO(issue#85) develop synchronization guard to monitor the freshness of the data

--- a/aegis_grpc/package.xml
+++ b/aegis_grpc/package.xml
@@ -19,6 +19,8 @@
   <depend>control_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libgrpc</depend>
+  <depend>moveit_msgs</depend>
+  <depend>moveit_ros_planning_interface</depend>
   <depend>protobuf-compiler-grpc</depend>
   <depend>protobuf-dev</depend>
   <depend>rclcpp</depend>

--- a/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
+++ b/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
@@ -282,9 +282,7 @@ class AegisRobotClient:
     async def goto_pose(
         self,
         position: Union[tuple[float, float, float], np.ndarray],  # np.array([vx,vy,vz])
-        orientation: Union[
-            tuple[float, float, float, float], np.ndarray
-        ],
+        orientation: Union[tuple[float, float, float, float], np.ndarray],
     ) -> tuple[bool, str]:
         """
         Move robot to specified TCP pose.
@@ -301,7 +299,7 @@ class AegisRobotClient:
             position = tuple(position.tolist())
         if isinstance(orientation, np.ndarray):
             orientation = tuple(orientation.tolist())
-        
+
         pose = geometry_msgs_pb2.Pose(
             position=geometry_msgs_pb2.Point(
                 x=position[0],

--- a/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
+++ b/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
@@ -287,7 +287,7 @@ class AegisRobotClient:
         Move robot to specified TCP pose.
 
         Args:
-            pose: Target Pose with position and orientation
+            pose: Target Pose with position and orientation (quaternion)
 
         Returns:
             (success, message) tuple
@@ -322,8 +322,8 @@ class AegisRobotClient:
 
     async def goto_joints(
         self,
-        names: list[str],
-        positions: Union[list[float], np.ndarray],
+        names: tuple[str],
+        positions: Union[tuple[float], np.ndarray],
     ) -> tuple[bool, str]:
         """
         Move robot to specified joint configuration.

--- a/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
+++ b/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
@@ -236,8 +236,8 @@ class AegisRobotClient:
 
     async def servo_tcp(
         self,
-        linear: Union[tuple[float, float, float], np.ndarray],  # np.array([vx,vy,vz])
-        angular: Union[tuple[float, float, float], np.ndarray],  # np.array([wx,wy,wz])
+        linear: Union[tuple[float, float, float], np.ndarray],
+        angular: Union[tuple[float, float, float], np.ndarray],
     ) -> None:
         """
         Perform TCP servo with Cartesian velocity control.
@@ -278,7 +278,6 @@ class AegisRobotClient:
             self.logger.error(f"ServoTCP failed: {e}")
             raise
 
-    # TODO(issue#83) add MoveIt2 actions to plan&execute trajectories to targets in Joints and Poses.
     async def goto_pose(
         self,
         position: Union[tuple[float, float, float], np.ndarray],
@@ -324,7 +323,7 @@ class AegisRobotClient:
     async def goto_joints(
         self,
         names: list[str],
-        positions: Optional[Union[list[float], np.ndarray]] = None,
+        positions: Union[list[float], np.ndarray],
     ) -> tuple[bool, str]:
         """
         Move robot to specified joint configuration.

--- a/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
+++ b/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
@@ -283,8 +283,8 @@ class AegisRobotClient:
         self,
         position: Union[tuple[float, float, float], np.ndarray],  # np.array([vx,vy,vz])
         orientation: Union[
-            tuple[float, float, float], np.ndarray
-        ],  # np.array([wx,wy,wz])
+            tuple[float, float, float, float], np.ndarray
+        ],
     ) -> tuple[bool, str]:
         """
         Move robot to specified TCP pose.
@@ -295,15 +295,33 @@ class AegisRobotClient:
         Returns:
             (success, message) tuple
         """
-        raise NotImplementedError
-        # TODO(issue#83) construct geometry_msgs_pb2.Pose message
-        # self._check_connected()
-        # try:
-        #     response = await self.control_stub.GotoPose(pose)
-        #     return response.success, response.msg
-        # except grpc.RpcError as e:
-        #     self.logger.error(f"GotoPose failed: {e}")
-        #     raise
+        self._check_connected()
+
+        if isinstance(position, np.ndarray):
+            position = tuple(position.tolist())
+        if isinstance(orientation, np.ndarray):
+            orientation = tuple(orientation.tolist())
+        
+        pose = geometry_msgs_pb2.Pose(
+            position=geometry_msgs_pb2.Point(
+                x=position[0],
+                y=position[1],
+                z=position[2],
+            ),
+            orientation=geometry_msgs_pb2.Quaternion(
+                x=orientation[0],
+                y=orientation[1],
+                z=orientation[2],
+                w=orientation[3],
+            ),
+        )
+
+        try:
+            response = await self.control_stub.GotoPose(pose)
+            return response.success, response.msg
+        except grpc.RpcError as e:
+            self.logger.error(f"Failed to send robot motion command: {e}")
+            raise
 
     # TODO(issue#83) add MoveIt2 actions to plan&execute trajectories to targets in Joints and Poses.
     async def goto_joints(
@@ -320,15 +338,22 @@ class AegisRobotClient:
         Returns:
             (success, message) tuple
         """
-        raise NotImplementedError
-        # TODO(issue#83) construct sensor_msgs_pb2.JointState message
-        # self._check_connected()
-        # try:
-        #     response = await self.control_stub.GotoJoints(joint_state)
-        #     return response.success, response.msg
-        # except grpc.RpcError as e:
-        #     self.logger.error(f"GotoJoints failed: {e}")
-        #     raise
+        self._check_connected()
+
+        if isinstance(positions, np.ndarray):
+            positions = positions.tolist()
+
+        joint_state = sensor_msgs_pb2.JointState(
+            name=names,
+            position=positions,
+        )
+
+        try:
+            response = await self.control_stub.GotoJoints(joint_state)
+            return response.success, response.msg
+        except grpc.RpcError as e:
+            self.logger.error(f"Failed to send robot motion command: {e}")
+            raise
 
     async def gripper_set_position(
         self, position: float, effort: float

--- a/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
+++ b/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
@@ -281,7 +281,7 @@ class AegisRobotClient:
     # TODO(issue#83) add MoveIt2 actions to plan&execute trajectories to targets in Joints and Poses.
     async def goto_pose(
         self,
-        position: Union[tuple[float, float, float], np.ndarray],  # np.array([vx,vy,vz])
+        position: Union[tuple[float, float, float], np.ndarray],
         orientation: Union[tuple[float, float, float, float], np.ndarray],
     ) -> tuple[bool, str]:
         """
@@ -296,9 +296,9 @@ class AegisRobotClient:
         self._check_connected()
 
         if isinstance(position, np.ndarray):
-            position = tuple(position.tolist())
+            position = tuple(position)
         if isinstance(orientation, np.ndarray):
-            orientation = tuple(orientation.tolist())
+            orientation = tuple(orientation)
 
         pose = geometry_msgs_pb2.Pose(
             position=geometry_msgs_pb2.Point(
@@ -321,7 +321,6 @@ class AegisRobotClient:
             self.logger.error(f"Failed to send robot motion command: {e}")
             raise
 
-    # TODO(issue#83) add MoveIt2 actions to plan&execute trajectories to targets in Joints and Poses.
     async def goto_joints(
         self,
         names: list[str],
@@ -339,7 +338,7 @@ class AegisRobotClient:
         self._check_connected()
 
         if isinstance(positions, np.ndarray):
-            positions = positions.tolist()
+            positions = tuple(positions)
 
         joint_state = sensor_msgs_pb2.JointState(
             name=names,

--- a/aegis_grpc/src/robot_control_service.cpp
+++ b/aegis_grpc/src/robot_control_service.cpp
@@ -27,6 +27,11 @@ RobotControlServiceImpl::RobotControlServiceImpl(
   DeclareROSParameter("r_gripper_close_m", 0.0, "[double] Runtime; Gripper close position in meters. ");
   DeclareROSParameter("r_gripper_open_m", 0.025, "[double] Runtime; Gripper open position in meters.");
 
+  move_group_ = std::make_unique<moveit::planning_interface::MoveGroupInterface>(
+    node_,
+    "aegis_arm"
+);
+
   servo_tcp_link_ = node_->get_parameter("servo_link").as_string();
 
   auto servo_in_hz = node_->get_parameter("servo_in_rate_hz").as_double();
@@ -269,6 +274,85 @@ grpc::Status RobotControlServiceImpl::GripperOpen(
   response->set_success(gripper_cmd_success_);
   response->set_msg(gripper_cmd_msg_);
   gripper_in_use_.store(false, std::memory_order_relaxed);
+  return grpc::Status::OK;
+}
+
+grpc::Status RobotControlServiceImpl::GotoPose(
+  grpc::ServerContext*,
+  const proto_aegis_grpc::v1::Pose *request,
+  proto_aegis_grpc::v1::TriggerResponse *response)
+{
+  geometry_msgs::msg::Pose pose;
+
+  if (!request->has_position() || !request->has_orientation()) {
+    response->set_success(false);
+    response->set_msg("Missing position or orientation");
+    return grpc::Status::OK;
+  }
+
+  pose.position.x = request->position().x();
+  pose.position.y = request->position().y();
+  pose.position.z = request->position().z();
+
+  pose.orientation.x = request->orientation().x();
+  pose.orientation.y = request->orientation().y();
+  pose.orientation.z = request->orientation().z();
+  pose.orientation.w = request->orientation().w();
+
+  move_group_->setPoseTarget(pose);
+
+  moveit::planning_interface::MoveGroupInterface::Plan plan;
+  auto result = move_group_->plan(plan);
+
+  if (result != moveit::core::MoveItErrorCode::SUCCESS) {
+      response->set_success(false);
+      response->set_msg("Planning failed");
+      return grpc::Status::OK;
+  }
+
+  auto exec = move_group_->execute(plan);
+  bool ok = (exec == moveit::core::MoveItErrorCode::SUCCESS);
+
+  response->set_success(ok);
+  response->set_msg(ok ? "OK" : "Execution failed");
+
+  return grpc::Status::OK;
+}
+
+grpc::Status RobotControlServiceImpl::GotoJoints(
+  grpc::ServerContext*,
+  const proto_aegis_grpc::v1::JointState *request,
+  proto_aegis_grpc::v1::TriggerResponse *response)
+{
+  std::map<std::string, double> target;
+
+  if (request->name_size() != request->position_size()) {
+    response->set_success(false);
+    response->set_msg("Name and position size mismatch");
+    return grpc::Status::OK;
+  }
+
+  for (int i = 0; i < request->name_size(); ++i) {
+      target[request->name(i)] = request->position(i);
+  }
+
+  move_group_->setJointValueTarget(target);
+
+  moveit::planning_interface::MoveGroupInterface::Plan plan;
+  auto result = move_group_->plan(plan);
+
+  if (result != moveit::core::MoveItErrorCode::SUCCESS) {
+      response->set_success(false);
+      response->set_msg("Planning failed");
+      return grpc::Status::OK;
+  }
+
+  auto exec = move_group_->execute(plan);
+  bool ok = (exec == moveit::core::MoveItErrorCode::SUCCESS);
+
+  response->set_success(ok);
+  response->set_msg(ok ? "OK" : "Execution failed");
+
   return grpc::Status::OK;
 }
 

--- a/aegis_grpc/src/robot_control_service.cpp
+++ b/aegis_grpc/src/robot_control_service.cpp
@@ -278,16 +278,20 @@ grpc::Status RobotControlServiceImpl::GripperOpen(
 }
 
 grpc::Status RobotControlServiceImpl::GotoPose(
-  grpc::ServerContext*,
+  grpc::ServerContext* context,
   const proto_aegis_grpc::v1::Pose *request,
-  proto_aegis_grpc::v1::TriggerResponse *response)
-{
+  proto_aegis_grpc::v1::TriggerResponse *response) {
+  (void)context;
+  
   geometry_msgs::msg::Pose pose;
-
+  response->set_success(false);
   if (!request->has_position() || !request->has_orientation()) {
-    response->set_success(false);
-    response->set_msg("Missing position or orientation");
-    return grpc::Status::OK;
+    std::string err =
+        "Missing position or orientation.";
+    RCLCPP_WARN(get_logger(), "[RobotControlService][GotoPose] %s",
+                err.c_str());
+    response->set_msg(err);
+    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, err);
   }
 
   pose.position.x = request->position().x();
@@ -305,31 +309,44 @@ grpc::Status RobotControlServiceImpl::GotoPose(
   auto result = move_group_->plan(plan);
 
   if (result != moveit::core::MoveItErrorCode::SUCCESS) {
-      response->set_success(false);
-      response->set_msg("Planning failed");
-      return grpc::Status::OK;
+    std::string err =
+        "Planning failed.";
+    RCLCPP_WARN(get_logger(), "[RobotControlService][GotoPose] %s",
+                err.c_str());
+    response->set_msg(err);
+    return grpc::Status(grpc::StatusCode::INTERNAL, err);
   }
 
   auto exec = move_group_->execute(plan);
-  bool ok = (exec == moveit::core::MoveItErrorCode::SUCCESS);
+  if(exec != moveit::core::MoveItErrorCode::SUCCESS) {
+      std::string err =
+          "Execution failed.";
+      RCLCPP_WARN(get_logger(), "[RobotControlService][GoToPose] %s", err.c_str());
+      response->set_msg(err);
+      return grpc::Status(grpc::StatusCode::INTERNAL, err);
+  }
 
-  response->set_success(ok);
-  response->set_msg(ok ? "OK" : "Execution failed");
-
+  response->set_success(true);
+  response->set_msg("");
   return grpc::Status::OK;
 }
 
 grpc::Status RobotControlServiceImpl::GotoJoints(
-  grpc::ServerContext*,
+  grpc::ServerContext* context,
   const proto_aegis_grpc::v1::JointState *request,
-  proto_aegis_grpc::v1::TriggerResponse *response)
-{
+  proto_aegis_grpc::v1::TriggerResponse *response) {
+  (void)context;
+  
   std::map<std::string, double> target;
+  response->set_success(false);
+  
 
   if (request->name_size() != request->position_size()) {
-    response->set_success(false);
-    response->set_msg("Name and position size mismatch");
-    return grpc::Status::OK;
+    std::string err =
+        "The numbers of names and positions do not match.";
+    RCLCPP_WARN(get_logger(), "[RobotControlService][GotoJoints] %s", err.c_str());
+    response->set_msg(err);
+    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, err);
   }
 
   for (int i = 0; i < request->name_size(); ++i) {
@@ -342,17 +359,24 @@ grpc::Status RobotControlServiceImpl::GotoJoints(
   auto result = move_group_->plan(plan);
 
   if (result != moveit::core::MoveItErrorCode::SUCCESS) {
-      response->set_success(false);
-      response->set_msg("Planning failed");
-      return grpc::Status::OK;
+std::string err =
+        "Planning failed.";
+    RCLCPP_WARN(get_logger(), "[RobotControlService][GotoJoints] %s", err.c_str());
+    response->set_msg(err);
+    return grpc::Status(grpc::StatusCode::INTERNAL, err);
   }
 
   auto exec = move_group_->execute(plan);
-  bool ok = (exec == moveit::core::MoveItErrorCode::SUCCESS);
+  if(exec != moveit::core::MoveItErrorCode::SUCCESS) {
+      std::string err =
+          "Execution failed.";
+      RCLCPP_WARN(get_logger(), "[RobotControlService][GotoJoints] %s", err.c_str());
+      response->set_msg(err);
+      return grpc::Status(grpc::StatusCode::INTERNAL, err);
+  }
 
-  response->set_success(ok);
-  response->set_msg(ok ? "OK" : "Execution failed");
-
+  response->set_success(true);
+  response->set_msg("");
   return grpc::Status::OK;
 }
 

--- a/aegis_grpc/src/robot_control_service.cpp
+++ b/aegis_grpc/src/robot_control_service.cpp
@@ -22,15 +22,11 @@ RobotControlServiceImpl::RobotControlServiceImpl(
   DeclareROSParameter("action_timeout_s", 3.0, "[double] Init; Waiting timeout for action in seconds.");
   DeclareROSParameter("servo_in_rate_hz", 10.0, "[double] Init; Servo commands frequency in Hz.");
   DeclareROSParameter("servo_out_rate_hz", 250.0, "[double] Init; Servo publish loop frequency in Hz.");
+  DeclareROSParameter("move_group", std::string("aegis_arm"), "[str] Init; Name of the planning group to control.");
 
   // Runtime parameters
   DeclareROSParameter("r_gripper_close_m", 0.0, "[double] Runtime; Gripper close position in meters. ");
   DeclareROSParameter("r_gripper_open_m", 0.025, "[double] Runtime; Gripper open position in meters.");
-
-  move_group_ = std::make_unique<moveit::planning_interface::MoveGroupInterface>(
-    node_,
-    "aegis_arm"
-);
 
   servo_tcp_link_ = node_->get_parameter("servo_link").as_string();
 
@@ -46,7 +42,6 @@ RobotControlServiceImpl::RobotControlServiceImpl(
   gripper_client_ = rclcpp_action::create_client<GripperCommand>(
       node_, node_->get_parameter("action_gripper").as_string());
 
-
   double hz = node_->get_parameter("servo_out_rate_hz").as_double();
   auto servo_pub_period = std::chrono::duration<double>(1.0 / hz);
 
@@ -55,6 +50,9 @@ RobotControlServiceImpl::RobotControlServiceImpl(
 
   auto action_timeout = node_->get_parameter("action_timeout_s").as_double();
   action_timeout_ = std::chrono::duration<double>(action_timeout);
+
+  auto move_group_name = node_->get_parameter("move_group").as_string();
+  move_group_ = std::make_unique<moveit::planning_interface::MoveGroupInterface>(node_, move_group_name);
 }
 
 rclcpp::Logger RobotControlServiceImpl::get_logger() const {
@@ -282,22 +280,20 @@ grpc::Status RobotControlServiceImpl::GotoPose(
   const proto_aegis_grpc::v1::Pose *request,
   proto_aegis_grpc::v1::TriggerResponse *response) {
   (void)context;
-  
-  geometry_msgs::msg::Pose pose;
+
   response->set_success(false);
+
   if (!request->has_position() || !request->has_orientation()) {
-    std::string err =
-        "Missing position or orientation.";
-    RCLCPP_WARN(get_logger(), "[RobotControlService][GotoPose] %s",
-                err.c_str());
+    std::string err = "Missing position or orientation.";
+    RCLCPP_WARN(get_logger(), "[RobotControlService][GotoPose] %s", err.c_str());
     response->set_msg(err);
     return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, err);
   }
 
+  geometry_msgs::msg::Pose pose;
   pose.position.x = request->position().x();
   pose.position.y = request->position().y();
   pose.position.z = request->position().z();
-
   pose.orientation.x = request->orientation().x();
   pose.orientation.y = request->orientation().y();
   pose.orientation.z = request->orientation().z();
@@ -307,20 +303,16 @@ grpc::Status RobotControlServiceImpl::GotoPose(
 
   moveit::planning_interface::MoveGroupInterface::Plan plan;
   auto result = move_group_->plan(plan);
-
   if (result != moveit::core::MoveItErrorCode::SUCCESS) {
-    std::string err =
-        "Planning failed.";
-    RCLCPP_WARN(get_logger(), "[RobotControlService][GotoPose] %s",
-                err.c_str());
+    std::string err = "Planning failed.";
+    RCLCPP_WARN(get_logger(), "[RobotControlService][GotoPose] %s", err.c_str());
     response->set_msg(err);
     return grpc::Status(grpc::StatusCode::INTERNAL, err);
   }
 
   auto exec = move_group_->execute(plan);
   if(exec != moveit::core::MoveItErrorCode::SUCCESS) {
-      std::string err =
-          "Execution failed.";
+      std::string err = "Execution failed.";
       RCLCPP_WARN(get_logger(), "[RobotControlService][GoToPose] %s", err.c_str());
       response->set_msg(err);
       return grpc::Status(grpc::StatusCode::INTERNAL, err);
@@ -336,19 +328,17 @@ grpc::Status RobotControlServiceImpl::GotoJoints(
   const proto_aegis_grpc::v1::JointState *request,
   proto_aegis_grpc::v1::TriggerResponse *response) {
   (void)context;
-  
-  std::map<std::string, double> target;
-  response->set_success(false);
-  
 
-  if (request->name_size() != request->position_size()) {
-    std::string err =
-        "The numbers of names and positions do not match.";
+  response->set_success(false);
+
+  if (request->name_size() == 0 || request->name_size() != request->position_size()) {
+    std::string err = "Joint names and positions mismatch or empty.";
     RCLCPP_WARN(get_logger(), "[RobotControlService][GotoJoints] %s", err.c_str());
     response->set_msg(err);
     return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, err);
   }
 
+  std::map<std::string, double> target;
   for (int i = 0; i < request->name_size(); ++i) {
       target[request->name(i)] = request->position(i);
   }
@@ -357,10 +347,8 @@ grpc::Status RobotControlServiceImpl::GotoJoints(
 
   moveit::planning_interface::MoveGroupInterface::Plan plan;
   auto result = move_group_->plan(plan);
-
   if (result != moveit::core::MoveItErrorCode::SUCCESS) {
-std::string err =
-        "Planning failed.";
+    std::string err = "Planning failed.";
     RCLCPP_WARN(get_logger(), "[RobotControlService][GotoJoints] %s", err.c_str());
     response->set_msg(err);
     return grpc::Status(grpc::StatusCode::INTERNAL, err);
@@ -368,8 +356,7 @@ std::string err =
 
   auto exec = move_group_->execute(plan);
   if(exec != moveit::core::MoveItErrorCode::SUCCESS) {
-      std::string err =
-          "Execution failed.";
+      std::string err = "Execution failed.";
       RCLCPP_WARN(get_logger(), "[RobotControlService][GotoJoints] %s", err.c_str());
       response->set_msg(err);
       return grpc::Status(grpc::StatusCode::INTERNAL, err);


### PR DESCRIPTION
## Description
Adds robot motion control via gRPC using MoveIt, enabling the robot to move to specified joint configurations or poses. Also updates the Python client to send these commands asynchronously.

*  Resolves #83.

## Motivation and context
Provides a way to move the robot to predefined positions, such as a home pose, for initialization, testing, or during learning and inference.

## How has this been tested?
In RViz. -> starting project with `mock_hardware:=true`

## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.