### PR TITLE
Reuduce DepthAI scene camera pipeline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         args: [-w]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.4
     hooks:
     -   id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
@@ -48,13 +48,13 @@ repos:
     -   id: cmake-lint
 
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v21.1.8
+    rev: v22.1.0
     hooks:
     -   id: clang-format
         types_or: [c++, proto]
 
 -   repo: https://github.com/tier4/pre-commit-hooks-ros
-    rev: v0.10.1
+    rev: v0.10.2
     hooks:
     -   id: prettier-xacro
     -   id: prettier-package-xml

--- a/aegis_control/CHANGELOG.md
+++ b/aegis_control/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* [PR-108](https://github.com/AGH-CEAI/aegis_ros/pull/108) - Reduced DepthAI pipeline for scene camera to RGB-only.
 * [PR-68](https://github.com/AGH-CEAI/aegis_ros/pull/68) - Changed gripper_action_controller's action monitor rate from `20` to `10` Hz.
 * [PR-60](https://github.com/AGH-CEAI/aegis_ros/pull/60) - Enabled all UR driver controllers.
 

--- a/aegis_control/config/cameras/depthai_cameras.yaml
+++ b/aegis_control/config/cameras/depthai_cameras.yaml
@@ -2,20 +2,20 @@
   ros__parameters:
     camera:
       i_mx_id: 184430108157970F00
-      i_nn_type: spatial
-      i_pipeline_type: RGBD
-    nn:
-      i_disable_resize: true
-      i_enable_passthrough: true
-    rgb:
-      i_enable_preview: true
-      i_keep_preview_aspect_ratio: true
-      i_preview_size: 416
-    stereo:
-      i_subpixel: true
-  spatial_bb_node:
-    ros__parameters:
-      desqueeze: true
+      i_pipeline_type: RGB # RGB, RGBD
+      # i_nn_type: spatial # rgb, spatial
+    # nn:
+    #   i_disable_resize: true
+    #   i_enable_passthrough: true
+    # rgb:
+    #   i_enable_preview: true
+    #   i_keep_preview_aspect_ratio: true
+    #   i_preview_size: 416
+    # stereo:
+    #   i_subpixel: true
+  # spatial_bb_node:
+  #   ros__parameters:
+  #     desqueeze: true
 /cam_tool_front:
   ros__parameters:
     camera:

--- a/aegis_control/config/cameras/depthai_cameras.yaml
+++ b/aegis_control/config/cameras/depthai_cameras.yaml
@@ -1,3 +1,4 @@
+# TODO(issue#107) Make DepthAI camera pipeline configurable
 /cam_scene:
   ros__parameters:
     camera:

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -61,7 +61,7 @@ class DepthAIConfig:
         self.cam_tool_pitch = LaunchConfiguration("cam_tool_pitch", default="1.5701")
         self.cam_tool_yaw = LaunchConfiguration("cam_tool_yaw", default="0")
 
-    def _modify_config(self, enable_nn: bool=False) -> None:
+    def _modify_config(self, enable_nn: bool = False) -> None:
         # TODO(issue#31) Fix YOLO configuration not being applied correctly
         package_share_path = Path(get_package_share_directory("aegis_control"))
         cam_src_params_path = (

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -19,7 +19,7 @@ from scipy.spatial.transform import Rotation
 
 class DepthAIConfig:
     def __init__(self):
-        self._modify_config()
+        self._modify_config(enable_nn=False)
 
         # TODO(issue#26) Introduce a mock for the DepthAI cameras
         self.mock_hardware = LaunchConfiguration("mock_hardware", default="false")
@@ -60,14 +60,19 @@ class DepthAIConfig:
         self.cam_tool_pitch = LaunchConfiguration("cam_tool_pitch", default="1.5701")
         self.cam_tool_yaw = LaunchConfiguration("cam_tool_yaw", default="0")
 
-    def _modify_config(self) -> None:
+    def _modify_config(self, enable_nn: bool=False) -> None:
         # TODO(issue#31) Fix YOLO configuration not being applied correctly
         package_share_path = Path(get_package_share_directory("aegis_control"))
-        model_path = Path.home() / "ceai_models" / "yolo.blob"
-        yolo_src_cfg_path = package_share_path / "config" / "cameras" / "yolo.json"
         cam_src_params_path = (
             package_share_path / "config" / "cameras" / "depthai_cameras.yaml"
         )
+
+        if not enable_nn:
+            self.cam_params_path = cam_src_params_path
+            return
+
+        model_path = Path.home() / "ceai_models" / "yolo.blob"
+        yolo_src_cfg_path = package_share_path / "config" / "cameras" / "yolo.json"
 
         self.yolo_cfg_path = Path(
             tempfile.NamedTemporaryFile(suffix=".json", delete=False).name
@@ -221,12 +226,12 @@ def launch_setup(context: LaunchContext) -> list[Node]:
 
     return [
         camera_scene_node,
-        camera_tool_node,
+        # camera_tool_node,
         rectify_scene_node,
         rectify_tool_right_node,
         rectify_tool_left_node,
-        spatial_bb_node,
-        point_cloud_node,
+        # spatial_bb_node,
+        # point_cloud_node,
         static_tf_scene_node,
         static_tf_tool_front_right_node,
         static_tf_tool_front_left_node,

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -61,7 +61,7 @@ class DepthAIConfig:
         self.cam_tool_pitch = LaunchConfiguration("cam_tool_pitch", default="1.5701")
         self.cam_tool_yaw = LaunchConfiguration("cam_tool_yaw", default="0")
 
-    def _modify_config(self, enable_nn: bool = False) -> None:
+    def _modify_config(self, enable_nn: bool) -> None:
         # TODO(issue#31) Fix YOLO configuration not being applied correctly
         package_share_path = Path(get_package_share_directory("aegis_control"))
         cam_src_params_path = (
@@ -202,10 +202,10 @@ def launch_setup(context: LaunchContext) -> list[Node]:
     rectify_tool_left_node = create_rectify_node(
         cfg.mock_hardware, cam_tool_name, "/left"
     )
-    spatial_bb_node = create_spatial_bb_node(
-        cfg.mock_hardware, cam_scene_name, cfg.cam_params_path
-    )
-    point_cloud_node = create_point_cloud_node(cfg.mock_hardware, cam_scene_name)
+    # spatial_bb_node = create_spatial_bb_node(
+    #     cfg.mock_hardware, cam_scene_name, cfg.cam_params_path
+    # )
+    # point_cloud_node = create_point_cloud_node(cfg.mock_hardware, cam_scene_name)
     static_tf_scene_node = create_static_tf_node(
         files_missing,
         calibration_extrinsics_paths,
@@ -225,9 +225,10 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         "cam_tool_front_left",
     )
 
+    # TODO(issue#107) Make DepthAI camera pipeline configurable
     return [
         camera_scene_node,
-        # camera_tool_node,
+        camera_tool_node,
         rectify_scene_node,
         rectify_tool_right_node,
         rectify_tool_left_node,

--- a/aegis_control/launch/depthai_cameras_driver.launch.py
+++ b/aegis_control/launch/depthai_cameras_driver.launch.py
@@ -17,6 +17,7 @@ from rclpy.logging import get_logger
 from scipy.spatial.transform import Rotation
 
 
+# TODO(issue#107) Make DepthAI camera pipeline configurable
 class DepthAIConfig:
     def __init__(self):
         self._modify_config(enable_nn=False)


### PR DESCRIPTION
## Description
This PR modifies the DepthAI pipeline for scene camera (Luxonis Pro PoE) to reduce processing load by disabling depth and neural network computations for the scene camera.
Introduces #107.


## Motivation and context
In previous setups, the scene camera occasionally stopped streaming and produced errors, likely caused by high CPU load on the camera. For training scenarios, higher frame rates are required, and switching to an RGB-only pipeline helps reduce processing load, preventing these errors and ensuring stable streaming.


## How has this been tested?
Manually, on Geonosis PC.


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [869c65g75](https://app.clickup.com/t/869c65g75)