### PR TITLE
Add enum with joint indexes for grpc client

### DIFF
--- a/aegis_grpc/CHANGELOG.md
+++ b/aegis_grpc/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* [PR-109](https://github.com/AGH-CEAI/aegis_ros/pull/109) - Client: Enum with indexes of all joints.
 * [PR-104](https://github.com/AGH-CEAI/aegis_ros/pull/104) - Server: Omit MoveIt2 call if the target is close to current pose.
 * [PR-103](https://github.com/AGH-CEAI/aegis_ros/pull/103) - Server: Adds servo idling with zero commands.
 * [PR-98](https://github.com/AGH-CEAI/aegis_ros/pull/98) - Added gRPC-based camera image reading.

--- a/aegis_grpc/python_client/aegis_grpc_client/__init__.py
+++ b/aegis_grpc/python_client/aegis_grpc_client/__init__.py
@@ -1,3 +1,3 @@
-from .grpc_client import AegisRobotClient
+from .grpc_client import AegisJointIndex, AegisRobotClient
 
-__all__ = ["AegisRobotClient"]
+__all__ = ["AegisJointIndex", "AegisRobotClient"]

--- a/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
+++ b/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
@@ -1,4 +1,5 @@
 import logging
+from enum import Enum
 from typing import Optional, Union
 from contextlib import asynccontextmanager
 
@@ -13,6 +14,16 @@ from proto_aegis_grpc.v1 import (
     control_msgs_pb2,
     sensor_msgs_pb2,
 )
+
+
+class AegisJointIndex(Enum):
+    ROBOTIQ_HANDE_LEFT_FINGER_JOINT = 0
+    SHOULDER_PAN_JOINT = 1
+    WRIST_3_JOINT = 2
+    WRIST_2_JOINT = 3
+    WRIST_1_JOINT = 4
+    ELBOW_JOINT = 5
+    SHOULDER_LIFT_JOINT = 6
 
 
 class PrefixedLoggerAdapter(logging.LoggerAdapter):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
An auxiliary python Enum for the grpc client, which helps to read a particular joint state.
Thanks to that, there is no need to introduce a dict inside joints array.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Easier access to the gripper's width.

<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually, during the development of AGH-CEAI/aegis_gym/pull/67

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [869c65gt5](https://app.clickup.com/t/869c65gt5)
