### PR TITLE
`aegis_grpc`: Server: parametrized the topics subs buffer size.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
     -   id: sort-package-xml
 
 -   repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.14
+    rev: 0.11.15
     hooks:
     -   id: uv-lock
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
 
-    rev: v0.15.12
+    rev: v0.15.13
     hooks:
     -   id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
@@ -63,7 +63,7 @@ repos:
     -   id: sort-package-xml
 
 -   repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.13
+    rev: 0.11.14
     hooks:
     -   id: uv-lock
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     -   id: cmake-lint
 
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.4
+    rev: v22.1.5
     hooks:
     -   id: clang-format
         types_or: [c++, proto]
@@ -63,7 +63,7 @@ repos:
     -   id: sort-package-xml
 
 -   repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.8
+    rev: 0.11.13
     hooks:
     -   id: uv-lock
 

--- a/aegis_grpc/CHANGELOG.md
+++ b/aegis_grpc/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+* [PR-119](https://github.com/AGH-CEAI/aegis_ros/pull/119) - Server: parametrized topics subs buffer size (and changed default from `10` to `1`).
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/aegis_grpc/README.md
+++ b/aegis_grpc/README.md
@@ -179,18 +179,19 @@ There is no hardcoded parameters, everything can be modified via ROS:
 
 **Initialization parameters**
 
-| Parameter             | Type     | Default                         | Units | Description                                      |
-| --------------------- | -------- | ------------------------------- | ----- | ------------------------------------------------ |
-| `tcp_frame`           | `string` | `"robotiq_hande_end"`           | -     | TF2 frame ID of the end-effector.                |
-| `base_frame`          | `string` | `"world"`                       | -     | TF2 base frame ID for EE pose lookup.            |
-| `topic_wrench`        | `string` | `"/wrench"`                     | -     | Topic providing force/torque (F/T) data.         |
-| `topic_joints`        | `string` | `"/joint_states"`               | -     | Topic providing joint state data.                |
-| `topic_camera_scene`  | `string` | `"/cam_scene/rgb/image_rect"`   | -     | Camera scene image topic.                        |
-| `topic_camera_right`  | `string` | `"/cam_tool_right/image_color"` | -     | Right tool camera image topic.                   |
-| `topic_camera_left`   | `string` | `"/cam_tool_left/image_color"`  | -     | Left tool camera image topic.                    |
-| `target_image_width`  | `int`    | `64`                            | px    | Target output image width in pixels.             |
-| `target_image_height` | `int`    | `64`                            | px    | Target output image height in pixels.            |
-| `enable_image_resize` | `bool`   | `true`                          | -     | Enable resizing images before sending over gRPC. |
+| Parameter              | Type     | Default                         | Units | Description                                      |
+| ---------------------- | -------- | ------------------------------- | ----- | ------------------------------------------------ |
+| `tcp_frame`            | `string` | `"robotiq_hande_end"`           | -     | TF2 frame ID of the end-effector.                |
+| `base_frame`           | `string` | `"world"`                       | -     | TF2 base frame ID for EE pose lookup.            |
+| `topic_wrench`         | `string` | `"/wrench"`                     | -     | Topic providing force/torque (F/T) data.         |
+| `topic_joints`         | `string` | `"/joint_states"`               | -     | Topic providing joint state data.                |
+| `topic_camera_scene`   | `string` | `"/cam_scene/rgb/image_rect"`   | -     | Camera scene image topic.                        |
+| `topic_camera_right`   | `string` | `"/cam_tool_right/image_color"` | -     | Right tool camera image topic.                   |
+| `topic_camera_left`    | `string` | `"/cam_tool_left/image_color"`  | -     | Left tool camera image topic.                    |
+| `topics_history_depth` | `int`    | `1`                             | -     | The topics messages history (buffer) size.       |
+| `target_image_width`   | `int`    | `64`                            | px    | Target output image width in pixels.             |
+| `target_image_height`  | `int`    | `64`                            | px    | Target output image height in pixels.            |
+| `enable_image_resize`  | `bool`   | `true`                          | -     | Enable resizing images before sending over gRPC. |
 
 >[!TIP]
 > The end-effector's TCP pose is obtained from the tf2 transform (using `tcp_frame` and `base_frame`).

--- a/aegis_grpc/launch/start_server.launch.py
+++ b/aegis_grpc/launch/start_server.launch.py
@@ -14,6 +14,7 @@ def generate_launch_description():
                         "tcp_frame": "robotiq_hande_end",
                         "base_frame": "world",
                         "topic_wrench": "/net_ft_sensor_broadcaster/wrench",
+                        "topics_history_depth": 1,
                     }
                 ],
             )

--- a/aegis_grpc/src/robot_read_service.cpp
+++ b/aegis_grpc/src/robot_read_service.cpp
@@ -23,20 +23,21 @@ RobotReadServiceImpl::RobotReadServiceImpl(std::shared_ptr<rclcpp::Node> node)
   tf_buffer_ = std::make_unique<tf2_ros::Buffer>(node_->get_clock());
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, node_, false);
 
+  // TODO parametrize the queue (buffer size) from the cofnig
   wrench_sub_ = node_->create_subscription<geometry_msgs::msg::WrenchStamped>(
-      node_->get_parameter("topic_wrench").as_string(), 10,
+      node_->get_parameter("topic_wrench").as_string(), 1,
       std::bind(&RobotReadServiceImpl::WrenchSubCb, this, std::placeholders::_1));
   joint_state_sub_ = node_->create_subscription<sensor_msgs::msg::JointState>(
-      node_->get_parameter("topic_joints").as_string(), 10,
+      node_->get_parameter("topic_joints").as_string(), 1,
       std::bind(&RobotReadServiceImpl::JointStateSubCb, this, std::placeholders::_1));
   image_scene_sub_ = node_->create_subscription<sensor_msgs::msg::Image>(
-      node_->get_parameter("topic_camera_scene").as_string(), 10,
+      node_->get_parameter("topic_camera_scene").as_string(), 1,
       std::bind(&RobotReadServiceImpl::ImageSceneSubCb, this, std::placeholders::_1));
   image_right_sub_ = node_->create_subscription<sensor_msgs::msg::Image>(
-      node_->get_parameter("topic_camera_right").as_string(), 10,
+      node_->get_parameter("topic_camera_right").as_string(), 1,
       std::bind(&RobotReadServiceImpl::ImageRightSubCb, this, std::placeholders::_1));
   image_left_sub_ = node_->create_subscription<sensor_msgs::msg::Image>(
-      node_->get_parameter("topic_camera_left").as_string(), 10,
+      node_->get_parameter("topic_camera_left").as_string(), 1,
       std::bind(&RobotReadServiceImpl::ImageLeftSubCb, this, std::placeholders::_1));
 
   tcp_frame_ = node_->get_parameter("tcp_frame").as_string();

--- a/aegis_grpc/src/robot_read_service.cpp
+++ b/aegis_grpc/src/robot_read_service.cpp
@@ -16,7 +16,7 @@ RobotReadServiceImpl::RobotReadServiceImpl(std::shared_ptr<rclcpp::Node> node)
                       "[str] Init; Sub: Camera scene image topic.");
   DeclareROSParameter("topic_camera_left", std::string("/cam_tool_left/image_color"),
                       "[str] Init; Sub:Camera scene image topic.");
-  DeclareROSParameter("topics_history_depth", 1, "[bool] Init; The message history (buffer) size.");
+  DeclareROSParameter("topics_history_depth", 1, "[bool] Init; The topics messages history (buffer) size.");
   DeclareROSParameter("target_image_width", 64, "[int] Init; Target output image width in pixels.");
   DeclareROSParameter("target_image_height", 64, "[int] Init; Target output image height in pixels.");
   DeclareROSParameter("enable_image_resize", true, "[bool] Init; Enable resizing images before sending over gRPC.");

--- a/aegis_grpc/src/robot_read_service.cpp
+++ b/aegis_grpc/src/robot_read_service.cpp
@@ -16,6 +16,7 @@ RobotReadServiceImpl::RobotReadServiceImpl(std::shared_ptr<rclcpp::Node> node)
                       "[str] Init; Sub: Camera scene image topic.");
   DeclareROSParameter("topic_camera_left", std::string("/cam_tool_left/image_color"),
                       "[str] Init; Sub:Camera scene image topic.");
+  DeclareROSParameter("topics_history_depth", 1, "[bool] Init; The message history (buffer) size.");
   DeclareROSParameter("target_image_width", 64, "[int] Init; Target output image width in pixels.");
   DeclareROSParameter("target_image_height", 64, "[int] Init; Target output image height in pixels.");
   DeclareROSParameter("enable_image_resize", true, "[bool] Init; Enable resizing images before sending over gRPC.");
@@ -23,21 +24,20 @@ RobotReadServiceImpl::RobotReadServiceImpl(std::shared_ptr<rclcpp::Node> node)
   tf_buffer_ = std::make_unique<tf2_ros::Buffer>(node_->get_clock());
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, node_, false);
 
-  // TODO parametrize the queue (buffer size) from the cofnig
   wrench_sub_ = node_->create_subscription<geometry_msgs::msg::WrenchStamped>(
-      node_->get_parameter("topic_wrench").as_string(), 1,
+      node_->get_parameter("topic_wrench").as_string(), node_->get_parameter("topics_history_depth").as_int(),
       std::bind(&RobotReadServiceImpl::WrenchSubCb, this, std::placeholders::_1));
   joint_state_sub_ = node_->create_subscription<sensor_msgs::msg::JointState>(
-      node_->get_parameter("topic_joints").as_string(), 1,
+      node_->get_parameter("topic_joints").as_string(), node_->get_parameter("topics_history_depth").as_int(),
       std::bind(&RobotReadServiceImpl::JointStateSubCb, this, std::placeholders::_1));
   image_scene_sub_ = node_->create_subscription<sensor_msgs::msg::Image>(
-      node_->get_parameter("topic_camera_scene").as_string(), 1,
+      node_->get_parameter("topic_camera_scene").as_string(), node_->get_parameter("topics_history_depth").as_int(),
       std::bind(&RobotReadServiceImpl::ImageSceneSubCb, this, std::placeholders::_1));
   image_right_sub_ = node_->create_subscription<sensor_msgs::msg::Image>(
-      node_->get_parameter("topic_camera_right").as_string(), 1,
+      node_->get_parameter("topic_camera_right").as_string(), node_->get_parameter("topics_history_depth").as_int(),
       std::bind(&RobotReadServiceImpl::ImageRightSubCb, this, std::placeholders::_1));
   image_left_sub_ = node_->create_subscription<sensor_msgs::msg::Image>(
-      node_->get_parameter("topic_camera_left").as_string(), 1,
+      node_->get_parameter("topic_camera_left").as_string(), node_->get_parameter("topics_history_depth").as_int(),
       std::bind(&RobotReadServiceImpl::ImageLeftSubCb, this, std::placeholders::_1));
 
   tcp_frame_ = node_->get_parameter("tcp_frame").as_string();

--- a/aegis_grpc/src/robot_read_service.cpp
+++ b/aegis_grpc/src/robot_read_service.cpp
@@ -290,7 +290,8 @@ void RobotReadServiceImpl::FillProtoImage(const sensor_msgs::msg::Image& ros,
                                           proto_aegis_grpc::v1::Image* out,
                                           cv::Mat& buffer) {
   if (ros.encoding != "bgr8") {
-    RCLCPP_ERROR(node_->get_logger(), "Unsupported image encoding (expected 'bgr8'), got: '%s'", ros.encoding.c_str());
+    RCLCPP_ERROR(node_->get_logger(), "[CAMERA FRAME: %s] Unsupported image encoding (expected 'bgr8'), got: '%s'",
+                 ros.header.frame_id.c_str(), ros.encoding.c_str());
     return;
   }
   if (!enable_image_resize_) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
After Sim2Real debug, we find out some bugfixes:

* `aegis_grpc`: change the buffer size of ROS messages from 10 to 1 

## Related PRs
* https://github.com/AGH-CEAI/aegis_gym/pull/113

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [869d15jvk](https://app.clickup.com/t/869d15jvk) & [869d9ywvr](https://app.clickup.com/t/869d9ywvr)
