### PR TITLE
Reorder gRPC joints, add enums with literals 

### DIFF
--- a/aegis_grpc/CHANGELOG.md
+++ b/aegis_grpc/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 
+* [PR-125](https://github.com/AGH-CEAI/aegis_ros/pull/125) - Client: Changed cameras names and introduced StrEnums for all literals.
 * [PR-119](https://github.com/AGH-CEAI/aegis_ros/pull/119) - Server: parametrized topics subs buffer size (and changed default from `10` to `1`).
 
 ### Deprecated

--- a/aegis_grpc/CHANGELOG.md
+++ b/aegis_grpc/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 
+* [PR-125](https://github.com/AGH-CEAI/aegis_ros/pull/125) - Client: Reordered the joints to match simulation joints order.
 * [PR-125](https://github.com/AGH-CEAI/aegis_ros/pull/125) - Client: Changed cameras names and introduced StrEnums for all literals.
 * [PR-119](https://github.com/AGH-CEAI/aegis_ros/pull/119) - Server: parametrized topics subs buffer size (and changed default from `10` to `1`).
 

--- a/aegis_grpc/include/aegis_grpc/robot_read_service.hpp
+++ b/aegis_grpc/include/aegis_grpc/robot_read_service.hpp
@@ -1,5 +1,6 @@
 #ifndef AEGIS_GRPC__ROBOT_READ_SERVICE_HPP_
 #define AEGIS_GRPC__ROBOT_READ_SERVICE_HPP_
+#include <array>
 #include <mutex>
 #include <opencv2/opencv.hpp>
 
@@ -20,6 +21,24 @@
 #include <tf2_ros/transform_listener.h>
 
 namespace aegis_grpc {
+
+constexpr std::array<std::string_view, 7> AEGIS_JOINT_ORDER = {
+    "shoulder_lift_joint",
+    "shoulder_pan_joint",
+    "elbow_joint",
+    "wrist_1_joint",
+    "wrist_2_joint",
+    "wrist_3_joint",
+    "robotiq_hande_left_finger_joint",
+};
+
+inline int FindJointIndex(const std::vector<std::string>& haystack, std::string_view name) {
+  for (std::size_t i = 0; i < haystack.size(); ++i) {
+    if (haystack[i] == name)
+      return static_cast<int>(i);
+  }
+  return -1;
+}
 
 class RobotReadServiceImpl final : public proto_aegis_grpc::v1::RobotReadService::Service {
  public:
@@ -79,7 +98,7 @@ class RobotReadServiceImpl final : public proto_aegis_grpc::v1::RobotReadService
 
   static void FillProtoWrench(const geometry_msgs::msg::Wrench& ros, proto_aegis_grpc::v1::Wrench* out);
 
-  static void FillProtoJointState(const sensor_msgs::msg::JointState& ros, proto_aegis_grpc::v1::JointState* out);
+  void FillProtoJointState(const sensor_msgs::msg::JointState& ros, proto_aegis_grpc::v1::JointState* out);
 
   void FillProtoImage(const sensor_msgs::msg::Image& ros, proto_aegis_grpc::v1::Image* out, cv::Mat& resize_buffer);
 

--- a/aegis_grpc/python_client/aegis_grpc_client/__init__.py
+++ b/aegis_grpc/python_client/aegis_grpc_client/__init__.py
@@ -1,3 +1,19 @@
-from .grpc_client import AegisJointIndex, AegisRobotClient
+from .grpc_client import (
+    AegisJointIndex,
+    AegisRobotClient,
+    AegisJointName,
+    AEGIS_JOINTS_ORDER,
+    CameraName,
+    ModalityGroup,
+    StateModality,
+)
 
-__all__ = ["AegisJointIndex", "AegisRobotClient"]
+__all__ = [
+    "AEGIS_JOINTS_ORDER",
+    "AegisJointIndex",
+    "AegisJointName",
+    "AegisRobotClient",
+    "CameraName",
+    "ModalityGroup",
+    "StateModality",
+]

--- a/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
+++ b/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
@@ -1,12 +1,12 @@
 import logging
-from enum import Enum
+from enum import Enum, auto
 from typing import Optional, Union
 from contextlib import asynccontextmanager
 
 import numpy as np
 import grpc
 from google.protobuf.empty_pb2 import Empty
-from strenum import StrEnum
+from strenum import StrEnum, LowercaseStrEnum
 
 from proto_aegis_grpc.v1 import (
     robot_srvs_pb2,
@@ -34,14 +34,35 @@ class StateModality(StrEnum):
     WRENCH = "wrench"
 
 
+class AegisJointName(LowercaseStrEnum):
+    ROBOTIQ_HANDE_LEFT_FINGER_JOINT = auto()
+    SHOULDER_PAN_JOINT = auto()
+    WRIST_3_JOINT = auto()
+    WRIST_2_JOINT = auto()
+    WRIST_1_JOINT = auto()
+    ELBOW_JOINT = auto()
+    SHOULDER_LIFT_JOINT = auto()
+
+
+AEGIS_JOINTS_ORDER: tuple[AegisJointName, ...] = (
+    AegisJointName.SHOULDER_PAN_JOINT,
+    AegisJointName.SHOULDER_LIFT_JOINT,
+    AegisJointName.ELBOW_JOINT,
+    AegisJointName.WRIST_1_JOINT,
+    AegisJointName.WRIST_2_JOINT,
+    AegisJointName.WRIST_3_JOINT,
+    AegisJointName.ROBOTIQ_HANDE_LEFT_FINGER_JOINT,
+)
+
+
 class AegisJointIndex(Enum):
-    ROBOTIQ_HANDE_LEFT_FINGER_JOINT = 0
-    SHOULDER_PAN_JOINT = 1
-    WRIST_3_JOINT = 2
-    WRIST_2_JOINT = 3
-    WRIST_1_JOINT = 4
-    ELBOW_JOINT = 5
-    SHOULDER_LIFT_JOINT = 6
+    SHOULDER_PAN_JOINT = 0
+    SHOULDER_LIFT_JOINT = 1
+    ELBOW_JOINT = 2
+    WRIST_1_JOINT = 3
+    WRIST_2_JOINT = 4
+    WRIST_3_JOINT = 5
+    ROBOTIQ_HANDE_LEFT_FINGER_JOINT = 6
 
 
 class PrefixedLoggerAdapter(logging.LoggerAdapter):

--- a/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
+++ b/aegis_grpc/python_client/aegis_grpc_client/grpc_client.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 import numpy as np
 import grpc
 from google.protobuf.empty_pb2 import Empty
+from strenum import StrEnum
 
 from proto_aegis_grpc.v1 import (
     robot_srvs_pb2,
@@ -14,6 +15,23 @@ from proto_aegis_grpc.v1 import (
     control_msgs_pb2,
     sensor_msgs_pb2,
 )
+
+
+class ModalityGroup(StrEnum):
+    STATE = "state"
+    VISION = "vision"
+
+
+class CameraName(StrEnum):
+    CAMERA_SCENE = "scene"
+    CAMERA_TOOL_LEFT = "tool_left"
+    CAMERA_TOOL_RIGHT = "tool_right"
+
+
+class StateModality(StrEnum):
+    POSE = "pose"
+    JOINTS = "joints"
+    WRENCH = "wrench"
 
 
 class AegisJointIndex(Enum):
@@ -161,9 +179,9 @@ class AegisRobotClient:
         try:
             state = await self.read_stub.GetRobotState(Empty())
             return {
-                "pose": self._pose_to_array(state.pose),
-                "wrench": self._wrench_to_array(state.wrench),
-                "joints": self._joints_to_array(state.joint_state),
+                StateModality.POSE: self._pose_to_array(state.pose),
+                StateModality.WRENCH: self._wrench_to_array(state.wrench),
+                StateModality.JOINTS: self._joints_to_array(state.joint_state),
             }
         except grpc.RpcError as e:
             self.logger.error(f"GetRobotState failed: {e}")
@@ -201,9 +219,9 @@ class AegisRobotClient:
         try:
             vision = await self.read_stub.GetRobotVision(Empty())
             return {
-                "scene": self._image_to_array(vision.image_scene),
-                "right": self._image_to_array(vision.image_right),
-                "left": self._image_to_array(vision.image_left),
+                CameraName.CAMERA_SCENE: self._image_to_array(vision.image_scene),
+                CameraName.CAMERA_TOOL_RIGHT: self._image_to_array(vision.image_right),
+                CameraName.CAMERA_TOOL_LEFT: self._image_to_array(vision.image_left),
             }
         except grpc.RpcError as e:
             self.logger.error(f"GetRobotVision failed: {e}")
@@ -214,15 +232,23 @@ class AegisRobotClient:
         try:
             obs = await self.read_stub.GetAll(Empty())
             return {
-                "state": {
-                    "pose": self._pose_to_array(obs.robot_state.pose),
-                    "wrench": self._wrench_to_array(obs.robot_state.wrench),
-                    "joints": self._joints_to_array(obs.robot_state.joint_state),
+                ModalityGroup.STATE: {
+                    StateModality.POSE: self._pose_to_array(obs.robot_state.pose),
+                    StateModality.WRENCH: self._wrench_to_array(obs.robot_state.wrench),
+                    StateModality.JOINTS: self._joints_to_array(
+                        obs.robot_state.joint_state
+                    ),
                 },
-                "vision": {
-                    "scene": self._image_to_array(obs.robot_vision.image_scene),
-                    "right": self._image_to_array(obs.robot_vision.image_right),
-                    "left": self._image_to_array(obs.robot_vision.image_left),
+                ModalityGroup.VISION: {
+                    CameraName.CAMERA_SCENE: self._image_to_array(
+                        obs.robot_vision.image_scene
+                    ),
+                    CameraName.CAMERA_TOOL_RIGHT: self._image_to_array(
+                        obs.robot_vision.image_right
+                    ),
+                    CameraName.CAMERA_TOOL_LEFT: self._image_to_array(
+                        obs.robot_vision.image_left
+                    ),
                 },
             }
         except grpc.RpcError as e:

--- a/aegis_grpc/python_client/pyproject.toml
+++ b/aegis_grpc/python_client/pyproject.toml
@@ -9,11 +9,12 @@ license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "grpcio<1.51",
     "grpcio-tools<1.51",
+    "grpcio<1.51",
     "numpy>=1.26.4",
     "proto-aegis-grpc",
     "protobuf<3.21",
+    "strenum>=0.4.15",
 ]
 
 [project.optional-dependencies]

--- a/aegis_grpc/python_client/pyproject.toml
+++ b/aegis_grpc/python_client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis_grpc_client"
-version = "0.1.0"
+version = "0.2.0"
 description = "A gRPC client to read and control the Aegis robot."
 authors = [
     { name = "AGH Center of Excellence in Artificial Intelligence", email = "ceai@agh.edu.pl" }

--- a/aegis_grpc/src/grpc_server_node.cpp
+++ b/aegis_grpc/src/grpc_server_node.cpp
@@ -1,5 +1,3 @@
-#include <memory>
-#include <vector>
 #include <thread>
 #include <string>
 

--- a/aegis_grpc/src/robot_control_service.cpp
+++ b/aegis_grpc/src/robot_control_service.cpp
@@ -1,4 +1,3 @@
-#include <thread>
 #include "aegis_grpc/robot_control_service.hpp"
 
 using namespace std::chrono_literals;

--- a/aegis_grpc/src/robot_read_service.cpp
+++ b/aegis_grpc/src/robot_read_service.cpp
@@ -276,14 +276,30 @@ void RobotReadServiceImpl::FillProtoJointState(const sensor_msgs::msg::JointStat
   out->clear_velocity();
   out->clear_effort();
 
-  for (const auto& v : ros.name)
-    out->add_name(v);
-  for (const auto& v : ros.position)
-    out->add_position(v);
-  for (const auto& v : ros.velocity)
-    out->add_velocity(v);
-  for (const auto& v : ros.effort)
-    out->add_effort(v);
+  const bool has_velocity = ros.velocity.size() == ros.name.size();
+  const bool has_effort = ros.effort.size() == ros.name.size();
+
+  out->mutable_name()->Reserve(AEGIS_JOINT_ORDER.size());
+  out->mutable_position()->Reserve(AEGIS_JOINT_ORDER.size());
+  if (has_velocity)
+    out->mutable_velocity()->Reserve(AEGIS_JOINT_ORDER.size());
+  if (has_effort)
+    out->mutable_effort()->Reserve(AEGIS_JOINT_ORDER.size());
+
+  for (const auto& target_name : AEGIS_JOINT_ORDER) {
+    const int idx = FindJointIndex(ros.name, target_name);
+    if (idx < 0) {
+      RCLCPP_ERROR(node_->get_logger(), "JointState is missing expected joint: %s", std::string(target_name).c_str());
+      continue;
+    }
+
+    out->add_name(std::string(target_name));
+    out->add_position(ros.position[idx]);
+    if (has_velocity)
+      out->add_velocity(ros.velocity[idx]);
+    if (has_effort)
+      out->add_effort(ros.effort[idx]);
+  }
 }
 
 void RobotReadServiceImpl::FillProtoImage(const sensor_msgs::msg::Image& ros,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
QoL: Match the order of the joins in genesis simulation (i.e. from the base to the TCP).

* Closes #110 

## Related PRs
* https://github.com/AGH-CEAI/aegis_gym/pull/144

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually on geonosis PC


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [869e1t35f](https://app.clickup.com/t/9012282053/869e1t35f)
