### PR TITLE
Hotfix: `wled_ros_driver` version & dashboard client 2.14.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
 
-    rev: v0.16.2
+    rev: v0.16.4
     hooks:
     -   id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
@@ -63,7 +63,7 @@ repos:
     -   id: sort-package-xml
 
 -   repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.12.2
+    rev: 0.12.6
     hooks:
     -   id: uv-lock
 

--- a/aegis/CHANGELOG.md
+++ b/aegis/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
+* [PR-137](https://github.com/AGH-CEAI/aegis_ros/pull/137) - Updated the `wled_ros_driver` repository.
 * [PR-134](https://github.com/AGH-CEAI/aegis_ros/pull/134) - Updated the `scene_objects_manager` repository (updated in PR #115).
 
 ### Security

--- a/aegis/aegis.repos
+++ b/aegis/aegis.repos
@@ -26,4 +26,4 @@ repositories:
   wled_ros_driver:
     type: git
     url: https://github.com/AGH-CEAI/wled_ros_driver.git
-    version: 1a344590a3ccc2849d30e94d6f9bef5fb5c313fb
+    version: 15dfba6689d0199855d1b23191fce088db7a463a

--- a/aegis_control/CHANGELOG.md
+++ b/aegis_control/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [PR-137](https://github.com/AGH-CEAI/aegis_ros/pull/137) - New UR dashboard client (2.14.0) workaround.
 * [PR-126](https://github.com/AGH-CEAI/aegis_ros/pull/126) - Fixed frame drops on the DepthAI rectified image by enabling intra-process comms and a multithreaded component container.
 
 ### Security

--- a/aegis_control/launch/ur_driver.launch.py
+++ b/aegis_control/launch/ur_driver.launch.py
@@ -42,6 +42,7 @@ def launch_setup(context: LaunchContext) -> list[Node]:
     dashboard_client_node = prepare_dashboard_client_node(mock_hardware, cfg)
     urscript_interface = prepare_urscript_interface(cfg)
     controller_stopper_node = prepare_controller_stopper_node(mock_hardware)
+    service_call_stop = prepare_service_call_stop()
     service_call_play = prepare_service_call_play()
 
     controllers_active = [
@@ -81,7 +82,8 @@ def launch_setup(context: LaunchContext) -> list[Node]:
         controller_stopper_node,
         controllers_spawner(controllers_active),
         controllers_spawner(controllers_inactive, active=False),
-        service_call_play,
+        service_call_stop,
+        *service_call_play,
     ]
 
 
@@ -155,16 +157,16 @@ def prepare_controller_stopper_node(mock_hardware: LaunchConfiguration) -> Node:
     )
 
 
-def prepare_service_call_play() -> TimerAction:
+def prepare_service_call_stop() -> TimerAction:
     return TimerAction(
-        period=5.0,  # s
+        period=1.0,  # s
         actions=[
             ExecuteProcess(
                 cmd=[
                     [
                         FindExecutable(name="ros2"),
                         " service call ",
-                        "/dashboard_client/play ",
+                        "/dashboard_client/stop ",
                         "std_srvs/srv/Trigger ",
                         "'{}'",
                     ]
@@ -173,3 +175,42 @@ def prepare_service_call_play() -> TimerAction:
             )
         ],
     )
+
+
+def prepare_service_call_play() -> TimerAction:
+    return [
+        TimerAction(
+            period=5.0,  # s
+            actions=[
+                ExecuteProcess(
+                    cmd=[
+                        [
+                            FindExecutable(name="ros2"),
+                            " service call ",
+                            "/dashboard_client/play ",
+                            "std_srvs/srv/Trigger ",
+                            "'{}'",
+                        ]
+                    ],
+                    shell=True,
+                )
+            ],
+        ),
+        TimerAction(
+            period=6.0,  # s
+            actions=[
+                ExecuteProcess(
+                    cmd=[
+                        [
+                            FindExecutable(name="ros2"),
+                            " service call ",
+                            "/dashboard_client/play ",
+                            "std_srvs/srv/Trigger ",
+                            "'{}'",
+                        ]
+                    ],
+                    shell=True,
+                )
+            ],
+        ),
+    ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Since we didn't have time to merge the #132 , `vcs` was downloading wrong version of the `wled_ros_driver` package. This PR fixes it.

In addition, the update of the `ur_robot_driver` from https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver to version 2.14.0 changed the behavior of the dashboard client (hypothesis: probably it was changed in https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1881) . The fastest workaround was to glue service calls to `/dashboard/stop` and 2x `/dashboard/play` with TimedAction. This should be polished in the future.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Project was not working.

<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually on the real hardware from all development accounts (@macmacal , @sivral , @AntoniRL)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [869ekwz8c](https://app.clickup.com/t/9012282053/869ekwz8c)
